### PR TITLE
fix: vérifier l'état actuel des paramètres GitHub avant de créer des actions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -610,12 +610,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "futures"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "65bc07b1a8bc7c85c5f2e110c476c7389b4554ba72af57d8445ea63a576b0876"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
 name = "futures-channel"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2dff15bf788c671c1934e366d07e30c1814a8ef514e1af724a602e8a2fbe1b10"
 dependencies = [
  "futures-core",
+ "futures-sink",
 ]
 
 [[package]]
@@ -623,6 +639,34 @@ name = "futures-core"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
+
+[[package]]
+name = "futures-executor"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e28d1d997f585e54aebc3f97d39e72338912123a67330d723fdbb564d646c9f"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-io"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e5c1b78ca4aae1ac06c48a526a655760685149f0d465d21f37abfe57ce075c6"
+
+[[package]]
+name = "futures-macro"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.114",
+]
 
 [[package]]
 name = "futures-sink"
@@ -642,8 +686,13 @@ version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
 dependencies = [
+ "futures-channel",
  "futures-core",
+ "futures-io",
+ "futures-macro",
+ "futures-sink",
  "futures-task",
+ "memchr",
  "pin-project-lite",
  "pin-utils",
  "slab",
@@ -1707,6 +1756,7 @@ dependencies = [
  "criterion",
  "dialoguer",
  "dirs",
+ "futures",
  "globset",
  "ignore",
  "indicatif",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -112,6 +112,7 @@ assert_cmd = "2"
 predicates = "3"
 pretty_assertions = "1"
 criterion = { version = "0.5", features = ["html_reports"] }
+futures = "0.3"
 
 [[bench]]
 name = "parse_benchmark"

--- a/src/actions/planner.rs
+++ b/src/actions/planner.rs
@@ -6,6 +6,7 @@
 use std::collections::HashMap;
 
 use crate::config::Config;
+use crate::providers::github::GitHubProvider;
 use crate::rules::results::AuditResults;
 
 use super::plan::{
@@ -61,7 +62,10 @@ impl ActionPlanner {
     /// # Returns
     ///
     /// An `ActionPlan` containing all planned actions
-    pub fn create_plan(&self, results: &AuditResults) -> ActionPlan {
+    pub async fn create_plan(
+        &self,
+        results: &AuditResults,
+    ) -> Result<ActionPlan, crate::error::RepoLensError> {
         let mut plan = ActionPlan::new();
 
         // Plan gitignore updates
@@ -99,15 +103,19 @@ impl ActionPlanner {
             }
         }
 
-        // Plan branch protection
+        // Plan branch protection (only if not already configured)
         if self.config.actions.branch_protection.enabled {
-            plan.add(self.plan_branch_protection());
+            if let Some(action) = self.plan_branch_protection_if_needed().await? {
+                plan.add(action);
+            }
         }
 
-        // Plan GitHub settings
-        plan.add(self.plan_github_settings());
+        // Plan GitHub settings (only if not already configured)
+        if let Some(action) = self.plan_github_settings_if_needed().await? {
+            plan.add(action);
+        }
 
-        plan
+        Ok(plan)
     }
 
     /// Plan .gitignore updates based on findings
@@ -291,15 +299,79 @@ impl ActionPlanner {
         )
     }
 
-    /// Plan branch protection configuration
+    /// Plan branch protection configuration if needed
     ///
-    /// Creates an action to configure branch protection settings based on
-    /// the configuration.
+    /// Checks the current branch protection status and creates an action only if
+    /// the current settings don't match the desired configuration.
     ///
     /// # Returns
     ///
-    /// An `Action` to configure branch protection
-    fn plan_branch_protection(&self) -> Action {
+    /// An `Action` to configure branch protection, or `None` if already configured correctly
+    async fn plan_branch_protection_if_needed(
+        &self,
+    ) -> Result<Option<Action>, crate::error::RepoLensError> {
+        let bp = &self.config.actions.branch_protection;
+
+        // Try to get current branch protection status
+        let provider = match GitHubProvider::new() {
+            Ok(p) => p,
+            Err(_) => {
+                // If GitHub CLI is not available, still plan the action
+                // (it will fail gracefully during apply)
+                return Ok(Some(self.create_branch_protection_action()));
+            }
+        };
+
+        let current_protection = match provider.get_branch_protection(&bp.branch) {
+            Ok(Some(protection)) => protection,
+            Ok(None) => {
+                // No protection exists, plan the action
+                return Ok(Some(self.create_branch_protection_action()));
+            }
+            Err(_) => {
+                // Error fetching protection, plan the action to be safe
+                return Ok(Some(self.create_branch_protection_action()));
+            }
+        };
+
+        // Check if current protection matches desired settings
+        let needs_update = {
+            // Check required approvals
+            let current_approvals = current_protection
+                .required_pull_request_reviews
+                .as_ref()
+                .map(|r| r.required_approving_review_count)
+                .unwrap_or(0);
+            let needs_approvals = current_approvals != bp.required_approvals;
+
+            // Check status checks
+            let has_status_checks = current_protection.required_status_checks.is_some();
+            let needs_status_checks = has_status_checks != bp.require_status_checks;
+
+            // Check force push blocking
+            // If block_force_push is true, we need allow_force_pushes.enabled to be false
+            // If block_force_push is false, we need allow_force_pushes.enabled to be true
+            let allows_force_push = current_protection
+                .allow_force_pushes
+                .as_ref()
+                .map(|a| a.enabled)
+                .unwrap_or(true);
+            // We need to update if: (block_force_push && allows_force_push) || (!block_force_push && !allows_force_push)
+            // Which simplifies to: allows_force_push == block_force_push
+            let needs_force_push_block = allows_force_push == bp.block_force_push;
+
+            needs_approvals || needs_status_checks || needs_force_push_block
+        };
+
+        if needs_update {
+            Ok(Some(self.create_branch_protection_action()))
+        } else {
+            Ok(None)
+        }
+    }
+
+    /// Create a branch protection action
+    fn create_branch_protection_action(&self) -> Action {
         let bp = &self.config.actions.branch_protection;
 
         let settings = BranchProtectionSettings {
@@ -335,15 +407,98 @@ impl ActionPlanner {
         .with_details(details)
     }
 
-    /// Plan GitHub repository settings updates
+    /// Plan GitHub repository settings updates if needed
     ///
-    /// Creates an action to update GitHub repository settings like discussions,
-    /// vulnerability alerts, etc.
+    /// Checks the current repository settings and creates an action only if
+    /// the current settings don't match the desired configuration.
     ///
     /// # Returns
     ///
-    /// An `Action` to update GitHub settings
-    fn plan_github_settings(&self) -> Action {
+    /// An `Action` to update GitHub settings, or `None` if already configured correctly
+    async fn plan_github_settings_if_needed(
+        &self,
+    ) -> Result<Option<Action>, crate::error::RepoLensError> {
+        let gs = &self.config.actions.github_settings;
+
+        // Try to get current repository settings
+        let provider = match GitHubProvider::new() {
+            Ok(p) => p,
+            Err(_) => {
+                // If GitHub CLI is not available, still plan the action
+                // (it will fail gracefully during apply)
+                return Ok(Some(self.create_github_settings_action()));
+            }
+        };
+
+        let current_settings = match provider.get_repo_settings() {
+            Ok(settings) => settings,
+            Err(_) => {
+                // Error fetching settings, plan the action to be safe
+                return Ok(Some(self.create_github_settings_action()));
+            }
+        };
+
+        // Check vulnerability alerts
+        let current_vuln_alerts = match provider.has_vulnerability_alerts() {
+            Ok(enabled) => enabled,
+            Err(e) => {
+                tracing::debug!("Could not check vulnerability alerts status: {:?}", e);
+                // If we can't check, assume it needs to be set (safer)
+                true
+            }
+        };
+        let needs_vuln_alerts = current_vuln_alerts != gs.vulnerability_alerts;
+
+        // Check automated security fixes
+        let current_auto_fixes = match provider.has_automated_security_fixes() {
+            Ok(enabled) => enabled,
+            Err(e) => {
+                tracing::debug!("Could not check automated security fixes status: {:?}", e);
+                // If we can't check, assume it needs to be set (safer)
+                true
+            }
+        };
+        let needs_auto_fixes = current_auto_fixes != gs.automated_security_fixes;
+
+        // Check discussions
+        let needs_discussions = current_settings.has_discussions_enabled != gs.discussions;
+
+        // Check issues (if configured)
+        let needs_issues = current_settings.has_issues_enabled != gs.issues;
+
+        // Check wiki (if configured)
+        let needs_wiki = current_settings.has_wiki_enabled != gs.wiki;
+
+        tracing::debug!(
+            "GitHub settings check: discussions={} (current={}, desired={}), vuln_alerts={} (current={}, desired={}), auto_fixes={} (current={}, desired={})",
+            needs_discussions,
+            current_settings.has_discussions_enabled,
+            gs.discussions,
+            needs_vuln_alerts,
+            current_vuln_alerts,
+            gs.vulnerability_alerts,
+            needs_auto_fixes,
+            current_auto_fixes,
+            gs.automated_security_fixes
+        );
+
+        // Only create action if something needs to be changed
+        if needs_discussions || needs_issues || needs_wiki || needs_vuln_alerts || needs_auto_fixes
+        {
+            Ok(Some(self.create_github_settings_action_filtered(
+                needs_discussions,
+                needs_issues,
+                needs_wiki,
+                needs_vuln_alerts,
+                needs_auto_fixes,
+            )))
+        } else {
+            Ok(None)
+        }
+    }
+
+    /// Create a GitHub settings action with all settings
+    fn create_github_settings_action(&self) -> Action {
         let gs = &self.config.actions.github_settings;
 
         let settings = GitHubRepoSettings {
@@ -363,6 +518,58 @@ impl ActionPlanner {
             details.push("Enable vulnerability alerts".to_string());
         }
         if gs.automated_security_fixes {
+            details.push("Enable automated security fixes".to_string());
+        }
+
+        Action::new(
+            "github-settings",
+            "github",
+            "Update repository settings",
+            ActionOperation::UpdateGitHubSettings { settings },
+        )
+        .with_details(details)
+    }
+
+    /// Create a GitHub settings action with only settings that need to be changed
+    fn create_github_settings_action_filtered(
+        &self,
+        needs_discussions: bool,
+        needs_issues: bool,
+        needs_wiki: bool,
+        needs_vuln_alerts: bool,
+        needs_auto_fixes: bool,
+    ) -> Action {
+        let gs = &self.config.actions.github_settings;
+
+        let settings = GitHubRepoSettings {
+            enable_discussions: if needs_discussions {
+                Some(gs.discussions)
+            } else {
+                None
+            },
+            enable_issues: if needs_issues { Some(gs.issues) } else { None },
+            enable_wiki: if needs_wiki { Some(gs.wiki) } else { None },
+            enable_vulnerability_alerts: if needs_vuln_alerts {
+                Some(gs.vulnerability_alerts)
+            } else {
+                None
+            },
+            enable_automated_security_fixes: if needs_auto_fixes {
+                Some(gs.automated_security_fixes)
+            } else {
+                None
+            },
+        };
+
+        let mut details = Vec::new();
+
+        if needs_discussions && gs.discussions {
+            details.push("Enable discussions".to_string());
+        }
+        if needs_vuln_alerts && gs.vulnerability_alerts {
+            details.push("Enable vulnerability alerts".to_string());
+        }
+        if needs_auto_fixes && gs.automated_security_fixes {
             details.push("Enable automated security fixes".to_string());
         }
 
@@ -395,7 +602,7 @@ mod tests {
             ".gitignore missing recommended entry: .env",
         ));
 
-        let plan = planner.create_plan(&results);
+        let plan = futures::executor::block_on(planner.create_plan(&results)).unwrap();
 
         assert!(!plan.is_empty());
         assert!(plan.actions().iter().any(|a| a.id() == "gitignore-update"));
@@ -414,7 +621,7 @@ mod tests {
             "LICENSE file is missing",
         ));
 
-        let plan = planner.create_plan(&results);
+        let plan = futures::executor::block_on(planner.create_plan(&results)).unwrap();
 
         assert!(plan.actions().iter().any(|a| a.id() == "license-create"));
     }
@@ -432,7 +639,7 @@ mod tests {
             "CONTRIBUTING file is missing",
         ));
 
-        let plan = planner.create_plan(&results);
+        let plan = futures::executor::block_on(planner.create_plan(&results)).unwrap();
 
         assert!(plan
             .actions()
@@ -455,7 +662,7 @@ mod tests {
             "CONTRIBUTING file is missing",
         ));
 
-        let plan = planner.create_plan(&results);
+        let plan = futures::executor::block_on(planner.create_plan(&results)).unwrap();
 
         // Should not include contributing because it's disabled in config
         assert!(!plan

--- a/src/cli/commands/apply.rs
+++ b/src/cli/commands/apply.rs
@@ -323,7 +323,7 @@ pub async fn execute(args: ApplyArgs) -> Result<i32, RepoLensError> {
 
     // Generate action plan
     let planner = ActionPlanner::new(config.clone());
-    let mut action_plan = planner.create_plan(&audit_results);
+    let mut action_plan = planner.create_plan(&audit_results).await?;
 
     // Apply filters if specified
     if let Some(only) = &args.only {

--- a/src/cli/commands/plan.rs
+++ b/src/cli/commands/plan.rs
@@ -123,7 +123,7 @@ pub async fn execute(args: PlanArgs) -> Result<i32, RepoLensError> {
     eprintln!("{}", "Génération du plan d'action...".dimmed());
     // Generate action plan
     let planner = ActionPlanner::new(config);
-    let action_plan = planner.create_plan(&audit_results);
+    let action_plan = planner.create_plan(&audit_results).await?;
 
     eprintln!("{}", "Génération du rapport...".dimmed());
     // Render output


### PR DESCRIPTION
## Problème

Lors de l'exécution de `plan` après un `apply`, les actions pour configurer les paramètres GitHub (discussions, vulnerability alerts, automated security fixes) et la protection de branche continuaient d'apparaître même si elles étaient déjà configurées correctement.

## Solution

### 1. Vérification de l'état actuel avant de créer des actions
- Le planner vérifie maintenant l'état actuel des paramètres GitHub via l'API avant de créer des actions
- Les actions ne sont créées que si les paramètres actuels ne correspondent pas à la configuration souhaitée
- `create_plan()` est maintenant asynchrone pour permettre les appels API

### 2. Actions filtrées
- Création d'une méthode `create_github_settings_action_filtered()` qui ne crée l'action qu'avec les paramètres qui doivent être modifiés
- Les paramètres déjà correctement configurés ne sont plus inclus dans l'action

### 3. Amélioration de la détection
- Ajout de méthodes dans `GitHubProvider` pour récupérer l'état actuel :
  - `get_repo_settings()` : récupère les paramètres du dépôt (discussions, issues, wiki)
  - `has_vulnerability_alerts()` : vérifie si les alertes de vulnérabilité sont activées
  - `has_automated_security_fixes()` : vérifie si les corrections automatiques sont activées
- Amélioration de la vérification des codes HTTP (accepte 200 OK en plus de 204 No Content)

### 4. Correction des warnings
- Ajout de `#[allow(dead_code)]` pour les champs utilisés uniquement pour la désérialisation
- Utilisation des champs `has_issues_enabled` et `has_wiki_enabled` dans la vérification

### 5. Gestion des erreurs améliorée
- Remplacement de `unwrap_or(false)` par une gestion d'erreur avec logging
- Ajout de logs de débogage pour tracer les valeurs actuelles vs désirées

## Fichiers modifiés

- `src/actions/planner.rs` : Vérification de l'état actuel avant de créer les actions
- `src/providers/github.rs` : Ajout de méthodes pour récupérer l'état actuel
- `src/cli/commands/plan.rs` : Mise à jour pour utiliser la version asynchrone
- `src/cli/commands/apply.rs` : Mise à jour pour utiliser la version asynchrone
- `Cargo.toml` : Ajout de `futures` dans les dev-dependencies pour les tests

## Tests

- Le code compile sans warnings
- Les actions ne sont plus créées si les paramètres sont déjà correctement configurés

Fixes #127