### PR TITLE
fix: apply creates warning issues even when action plan is empty

### DIFF
--- a/src/cli/commands/apply.rs
+++ b/src/cli/commands/apply.rs
@@ -373,9 +373,16 @@ pub async fn execute(args: ApplyArgs) -> Result<i32, RepoLensError> {
         action_plan.filter_skip(skip);
     }
 
-    // Check if there are any actions to perform
-    if action_plan.is_empty() {
+    // Check if there are any actions or warning issues to create
+    let has_warnings = audit_results.has_warnings();
+    if action_plan.is_empty() && (!has_warnings || args.no_issues) {
         println!("{}", "No actions to perform.".green());
+        return Ok(exit_codes::SUCCESS);
+    }
+
+    // If only warning issues to create (no plan actions), handle that directly
+    if action_plan.is_empty() && has_warnings && !args.no_issues {
+        create_warning_issues(&audit_results);
         return Ok(exit_codes::SUCCESS);
     }
 


### PR DESCRIPTION
## Summary

- When `apply` has no file/settings actions but warnings exist, it now runs `create_warning_issues()` instead of exiting with "No actions to perform"
- The `--no-issues` flag is respected: if set, it still shows "No actions to perform"
- Fixes the inconsistency where `plan` shows pending issues but `apply` does nothing

## Test plan

- [x] `cargo check` — clean
- [x] `cargo clippy` — clean
- [x] `cargo test` — 623 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)