### PR TITLE
feat: add Docker rules, CI/CD rules, quality rules, CHANGELOG rules, Java and PHP ecosystems

### DIFF
--- a/src/config/presets/mod.rs
+++ b/src/config/presets/mod.rs
@@ -54,12 +54,18 @@ impl Preset {
                 "docs/contributing",
                 "docs/code-of-conduct",
                 "docs/security",
+                "docs/changelog",
                 "files/sensitive",
                 "files/large",
                 "files/gitignore",
                 "security/dependencies",
                 "workflows/secrets",
                 "workflows/permissions",
+                "workflows/linters-in-ci",
+                "docker/dockerfile-presence",
+                "docker/dockerignore",
+                "docker/from-pinning",
+                "docker/user",
                 "github/branch-protection",
                 "github/settings",
             ],
@@ -77,6 +83,15 @@ impl Preset {
                 "security/signed-commits",
                 "workflows/secrets",
                 "workflows/permissions",
+                "workflows/timeout",
+                "workflows/pull-request-target",
+                "docker/dockerfile-presence",
+                "docker/dockerignore",
+                "docker/from-pinning",
+                "docker/user",
+                "docker/secrets-in-env",
+                "docker/healthcheck",
+                "quality/coverage",
                 "github/branch-protection",
                 "github/settings",
             ],
@@ -91,6 +106,8 @@ impl Preset {
                 "docs/code-of-conduct",
                 "docs/security",
                 "docs/changelog",
+                "docs/changelog-format",
+                "docs/changelog-unreleased",
                 "files/sensitive",
                 "files/large",
                 "files/gitignore",
@@ -101,10 +118,29 @@ impl Preset {
                 "workflows/secrets",
                 "workflows/permissions",
                 "workflows/pinned-actions",
-                "github/branch-protection",
-                "github/settings",
+                "workflows/timeout",
+                "workflows/concurrency",
+                "workflows/reusable-workflows",
+                "workflows/artifacts-retention",
+                "workflows/pull-request-target",
+                "workflows/linters-in-ci",
+                "docker/dockerfile-presence",
+                "docker/dockerignore",
+                "docker/from-pinning",
+                "docker/user",
+                "docker/healthcheck",
+                "docker/multistage",
+                "docker/secrets-in-env",
+                "docker/copy-all",
                 "quality/tests",
                 "quality/linting",
+                "quality/coverage",
+                "quality/api-docs",
+                "quality/complexity",
+                "quality/dead-code",
+                "quality/naming-conventions",
+                "github/branch-protection",
+                "github/settings",
             ],
         }
     }
@@ -122,6 +158,7 @@ impl Preset {
                 "docs/license",
                 "security/codeowners",
                 "security/signed-commits",
+                "docker/from-pinning",
             ],
         }
     }
@@ -202,6 +239,34 @@ mod tests {
         assert!(rules.contains(&"quality/tests"));
         assert!(rules.contains(&"quality/linting"));
         assert!(rules.contains(&"workflows/pinned-actions"));
+        // New rules
+        assert!(rules.contains(&"docker/from-pinning"));
+        assert!(rules.contains(&"workflows/timeout"));
+        assert!(rules.contains(&"quality/coverage"));
+        assert!(rules.contains(&"docs/changelog-format"));
+    }
+
+    #[test]
+    fn test_preset_enabled_rules_opensource_new() {
+        let rules = Preset::OpenSource.enabled_rules();
+        assert!(rules.contains(&"docs/changelog"));
+        assert!(rules.contains(&"workflows/linters-in-ci"));
+        assert!(rules.contains(&"docker/dockerfile-presence"));
+    }
+
+    #[test]
+    fn test_preset_enabled_rules_enterprise_new() {
+        let rules = Preset::Enterprise.enabled_rules();
+        assert!(rules.contains(&"workflows/timeout"));
+        assert!(rules.contains(&"workflows/pull-request-target"));
+        assert!(rules.contains(&"docker/from-pinning"));
+        assert!(rules.contains(&"quality/coverage"));
+    }
+
+    #[test]
+    fn test_preset_critical_rules_strict_docker() {
+        let rules = Preset::Strict.critical_rules();
+        assert!(rules.contains(&"docker/from-pinning"));
     }
 
     #[test]

--- a/src/rules/categories/docker.rs
+++ b/src/rules/categories/docker.rs
@@ -1,0 +1,939 @@
+//! Docker rules
+//!
+//! This module provides rules for checking Dockerfile best practices, including:
+//! - Dockerfile presence and `.dockerignore` configuration
+//! - Pinned base image tags
+//! - Security practices (USER instruction, secrets in ENV/ARG)
+//! - Health checks and multi-stage builds
+//! - COPY patterns
+
+use crate::config::Config;
+use crate::error::RepoLensError;
+use crate::rules::engine::RuleCategory;
+use crate::rules::results::{Finding, Severity};
+use crate::scanner::Scanner;
+
+/// Rules for checking Dockerfile best practices
+pub struct DockerRules;
+
+#[async_trait::async_trait]
+impl RuleCategory for DockerRules {
+    fn name(&self) -> &'static str {
+        "docker"
+    }
+
+    async fn run(&self, scanner: &Scanner, config: &Config) -> Result<Vec<Finding>, RepoLensError> {
+        let mut findings = Vec::new();
+
+        if config.is_rule_enabled("docker/dockerfile-presence") {
+            findings.extend(check_dockerfile_presence(scanner).await?);
+        }
+
+        if config.is_rule_enabled("docker/dockerignore") {
+            findings.extend(check_dockerignore(scanner).await?);
+        }
+
+        if config.is_rule_enabled("docker/pinned-tag") {
+            findings.extend(check_pinned_tag(scanner).await?);
+        }
+
+        if config.is_rule_enabled("docker/user-instruction") {
+            findings.extend(check_user_instruction(scanner).await?);
+        }
+
+        if config.is_rule_enabled("docker/healthcheck") {
+            findings.extend(check_healthcheck(scanner).await?);
+        }
+
+        if config.is_rule_enabled("docker/multi-stage") {
+            findings.extend(check_multi_stage(scanner).await?);
+        }
+
+        if config.is_rule_enabled("docker/secrets-in-env") {
+            findings.extend(check_secrets_in_env(scanner).await?);
+        }
+
+        if config.is_rule_enabled("docker/copy-all") {
+            findings.extend(check_copy_all(scanner).await?);
+        }
+
+        Ok(findings)
+    }
+}
+
+/// Find all Dockerfile paths in the repository
+fn find_dockerfiles(scanner: &Scanner) -> Vec<String> {
+    let mut paths = Vec::new();
+    if scanner.file_exists("Dockerfile") {
+        paths.push("Dockerfile".to_string());
+    }
+    for file_info in scanner.files_matching_pattern("Dockerfile.*") {
+        // Exclude patterns like Dockerfile.md or similar non-Dockerfile files
+        // but include Dockerfile.dev, Dockerfile.prod, etc.
+        paths.push(file_info.path.clone());
+    }
+    for file_info in scanner.files_matching_pattern("*.Dockerfile") {
+        paths.push(file_info.path.clone());
+    }
+    paths.sort();
+    paths.dedup();
+    paths
+}
+
+/// DOCKER001: Dockerfile absent but docker-compose.yml or .dockerignore exists
+async fn check_dockerfile_presence(scanner: &Scanner) -> Result<Vec<Finding>, RepoLensError> {
+    let mut findings = Vec::new();
+
+    let dockerfiles = find_dockerfiles(scanner);
+    let has_dockerfile = !dockerfiles.is_empty();
+
+    let has_compose = scanner.file_exists("docker-compose.yml")
+        || scanner.file_exists("docker-compose.yaml")
+        || scanner.file_exists("compose.yml")
+        || scanner.file_exists("compose.yaml");
+    let has_dockerignore = scanner.file_exists(".dockerignore");
+
+    if !has_dockerfile && (has_compose || has_dockerignore) {
+        findings.push(
+            Finding::new(
+                "DOCKER001",
+                "docker",
+                Severity::Warning,
+                "Dockerfile is missing but Docker-related files exist",
+            )
+            .with_description(
+                "A docker-compose file or .dockerignore was found, but no Dockerfile exists. \
+                 This suggests Docker is intended but the Dockerfile may be missing.",
+            )
+            .with_remediation("Create a Dockerfile to define your container image."),
+        );
+    }
+
+    Ok(findings)
+}
+
+/// DOCKER002: .dockerignore absent when Dockerfile exists
+async fn check_dockerignore(scanner: &Scanner) -> Result<Vec<Finding>, RepoLensError> {
+    let mut findings = Vec::new();
+
+    let dockerfiles = find_dockerfiles(scanner);
+    let has_dockerfile = !dockerfiles.is_empty();
+    let has_dockerignore = scanner.file_exists(".dockerignore");
+
+    if has_dockerfile && !has_dockerignore {
+        findings.push(
+            Finding::new(
+                "DOCKER002",
+                "docker",
+                Severity::Warning,
+                ".dockerignore file is missing",
+            )
+            .with_description(
+                "A Dockerfile exists but no .dockerignore was found. Without a .dockerignore, \
+                 unnecessary files may be included in the Docker build context, increasing \
+                 image size and potentially leaking sensitive data.",
+            )
+            .with_remediation(
+                "Create a .dockerignore file to exclude unnecessary files from the build context \
+                 (e.g., .git, node_modules, .env).",
+            ),
+        );
+    }
+
+    Ok(findings)
+}
+
+/// DOCKER003: FROM not pinned (uses :latest or no tag)
+async fn check_pinned_tag(scanner: &Scanner) -> Result<Vec<Finding>, RepoLensError> {
+    let mut findings = Vec::new();
+
+    let dockerfiles = find_dockerfiles(scanner);
+
+    for dockerfile_path in &dockerfiles {
+        let content = match scanner.read_file(dockerfile_path) {
+            Ok(c) => c,
+            Err(_) => continue,
+        };
+
+        for (line_num, line) in content.lines().enumerate() {
+            let trimmed = line.trim();
+            if !trimmed.to_uppercase().starts_with("FROM ") {
+                continue;
+            }
+
+            // Parse the FROM instruction: FROM image[:tag] [AS name]
+            let parts: Vec<&str> = trimmed.split_whitespace().collect();
+            if parts.len() < 2 {
+                continue;
+            }
+
+            let image = parts[1];
+
+            // Skip scratch (special Docker image with no tag)
+            if image == "scratch" {
+                continue;
+            }
+
+            // Skip variable references like $BASE_IMAGE or ${BASE_IMAGE}
+            if image.starts_with('$') {
+                continue;
+            }
+
+            // Check if the image has a tag
+            let has_tag = if let Some(colon_pos) = image.rfind(':') {
+                // Check it's not a port in a registry URL (e.g., registry:5000/image)
+                let after_colon = &image[colon_pos + 1..];
+                // If after colon contains '/', it's a registry port, not a tag
+                !after_colon.contains('/')
+            } else {
+                false
+            };
+
+            if !has_tag {
+                findings.push(
+                    Finding::new(
+                        "DOCKER003",
+                        "docker",
+                        Severity::Critical,
+                        format!("Base image '{}' is not pinned to a specific tag", image),
+                    )
+                    .with_location(format!("{}:{}", dockerfile_path, line_num + 1))
+                    .with_description(
+                        "Using an unpinned base image (no tag or implicit :latest) can lead to \
+                         non-reproducible builds and unexpected behavior when the upstream \
+                         image changes.",
+                    )
+                    .with_remediation(
+                        "Pin the base image to a specific version tag, e.g., 'node:20-alpine' \
+                         instead of 'node' or 'node:latest'.",
+                    ),
+                );
+            } else {
+                // Check if the tag is 'latest'
+                let tag = image.rsplit(':').next().unwrap_or("");
+                if tag == "latest" {
+                    findings.push(
+                        Finding::new(
+                            "DOCKER003",
+                            "docker",
+                            Severity::Critical,
+                            format!("Base image '{}' uses the 'latest' tag", image),
+                        )
+                        .with_location(format!("{}:{}", dockerfile_path, line_num + 1))
+                        .with_description(
+                            "Using the ':latest' tag is equivalent to not pinning the image. \
+                             It can lead to non-reproducible builds.",
+                        )
+                        .with_remediation(
+                            "Pin the base image to a specific version tag, e.g., 'node:20-alpine' \
+                             instead of 'node:latest'.",
+                        ),
+                    );
+                }
+            }
+        }
+    }
+
+    Ok(findings)
+}
+
+/// DOCKER004: No USER instruction (running as root)
+async fn check_user_instruction(scanner: &Scanner) -> Result<Vec<Finding>, RepoLensError> {
+    let mut findings = Vec::new();
+
+    let dockerfiles = find_dockerfiles(scanner);
+
+    for dockerfile_path in &dockerfiles {
+        let content = match scanner.read_file(dockerfile_path) {
+            Ok(c) => c,
+            Err(_) => continue,
+        };
+
+        let has_user = content
+            .lines()
+            .any(|line| line.trim().to_uppercase().starts_with("USER "));
+
+        if !has_user {
+            findings.push(
+                Finding::new(
+                    "DOCKER004",
+                    "docker",
+                    Severity::Warning,
+                    format!("No USER instruction in {}", dockerfile_path),
+                )
+                .with_location(dockerfile_path.as_str())
+                .with_description(
+                    "Without a USER instruction, the container runs as root by default, \
+                     which increases the attack surface if the container is compromised.",
+                )
+                .with_remediation(
+                    "Add a USER instruction to run the container as a non-root user, \
+                     e.g., 'USER 1001' or 'USER appuser'.",
+                ),
+            );
+        }
+    }
+
+    Ok(findings)
+}
+
+/// DOCKER005: No HEALTHCHECK instruction
+async fn check_healthcheck(scanner: &Scanner) -> Result<Vec<Finding>, RepoLensError> {
+    let mut findings = Vec::new();
+
+    let dockerfiles = find_dockerfiles(scanner);
+
+    for dockerfile_path in &dockerfiles {
+        let content = match scanner.read_file(dockerfile_path) {
+            Ok(c) => c,
+            Err(_) => continue,
+        };
+
+        let has_healthcheck = content
+            .lines()
+            .any(|line| line.trim().to_uppercase().starts_with("HEALTHCHECK "));
+
+        if !has_healthcheck {
+            findings.push(
+                Finding::new(
+                    "DOCKER005",
+                    "docker",
+                    Severity::Warning,
+                    format!("No HEALTHCHECK instruction in {}", dockerfile_path),
+                )
+                .with_location(dockerfile_path.as_str())
+                .with_description(
+                    "Without a HEALTHCHECK instruction, Docker has no way to determine if the \
+                     container's main process is still healthy. This limits orchestrator \
+                     capabilities for automatic restart and load balancing.",
+                )
+                .with_remediation(
+                    "Add a HEALTHCHECK instruction, e.g., \
+                     'HEALTHCHECK CMD curl -f http://localhost/ || exit 1'.",
+                ),
+            );
+        }
+    }
+
+    Ok(findings)
+}
+
+/// DOCKER006: No multi-stage build (only 1 FROM)
+async fn check_multi_stage(scanner: &Scanner) -> Result<Vec<Finding>, RepoLensError> {
+    let mut findings = Vec::new();
+
+    let dockerfiles = find_dockerfiles(scanner);
+
+    for dockerfile_path in &dockerfiles {
+        let content = match scanner.read_file(dockerfile_path) {
+            Ok(c) => c,
+            Err(_) => continue,
+        };
+
+        let from_count = content
+            .lines()
+            .filter(|line| line.trim().to_uppercase().starts_with("FROM "))
+            .count();
+
+        if from_count == 1 {
+            findings.push(
+                Finding::new(
+                    "DOCKER006",
+                    "docker",
+                    Severity::Info,
+                    format!("No multi-stage build in {}", dockerfile_path),
+                )
+                .with_location(dockerfile_path.as_str())
+                .with_description(
+                    "The Dockerfile uses a single stage. Multi-stage builds can reduce final \
+                     image size by separating build dependencies from runtime dependencies.",
+                )
+                .with_remediation(
+                    "Consider using a multi-stage build to separate build and runtime stages, \
+                     resulting in a smaller and more secure final image.",
+                ),
+            );
+        }
+    }
+
+    Ok(findings)
+}
+
+/// DOCKER007: Secrets in ENV/ARG instructions
+async fn check_secrets_in_env(scanner: &Scanner) -> Result<Vec<Finding>, RepoLensError> {
+    let mut findings = Vec::new();
+
+    let secret_patterns = [
+        "password",
+        "passwd",
+        "secret",
+        "token",
+        "api_key",
+        "apikey",
+        "api-key",
+        "private_key",
+        "access_key",
+        "secret_key",
+        "credentials",
+    ];
+
+    let dockerfiles = find_dockerfiles(scanner);
+
+    for dockerfile_path in &dockerfiles {
+        let content = match scanner.read_file(dockerfile_path) {
+            Ok(c) => c,
+            Err(_) => continue,
+        };
+
+        for (line_num, line) in content.lines().enumerate() {
+            let trimmed = line.trim();
+            let upper = trimmed.to_uppercase();
+
+            if !upper.starts_with("ENV ") && !upper.starts_with("ARG ") {
+                continue;
+            }
+
+            let lower = trimmed.to_lowercase();
+            for pattern in &secret_patterns {
+                if lower.contains(pattern) {
+                    findings.push(
+                        Finding::new(
+                            "DOCKER007",
+                            "docker",
+                            Severity::Warning,
+                            format!(
+                                "Potential secret in {} instruction",
+                                if upper.starts_with("ENV ") {
+                                    "ENV"
+                                } else {
+                                    "ARG"
+                                }
+                            ),
+                        )
+                        .with_location(format!("{}:{}", dockerfile_path, line_num + 1))
+                        .with_description(format!(
+                            "The instruction contains '{}' which may indicate a secret or \
+                             credential. Secrets in ENV/ARG instructions are baked into \
+                             the image layers and can be extracted.",
+                            pattern
+                        ))
+                        .with_remediation(
+                            "Use Docker build secrets (--mount=type=secret) or runtime \
+                             environment variables instead of embedding secrets in the image.",
+                        ),
+                    );
+                    break; // Only report once per line
+                }
+            }
+        }
+    }
+
+    Ok(findings)
+}
+
+/// DOCKER008: COPY . . used without .dockerignore
+async fn check_copy_all(scanner: &Scanner) -> Result<Vec<Finding>, RepoLensError> {
+    let mut findings = Vec::new();
+
+    let has_dockerignore = scanner.file_exists(".dockerignore");
+
+    let dockerfiles = find_dockerfiles(scanner);
+
+    for dockerfile_path in &dockerfiles {
+        let content = match scanner.read_file(dockerfile_path) {
+            Ok(c) => c,
+            Err(_) => continue,
+        };
+
+        for (line_num, line) in content.lines().enumerate() {
+            let trimmed = line.trim();
+            if !trimmed.to_uppercase().starts_with("COPY ") {
+                continue;
+            }
+
+            // Check for "COPY . ." or "COPY . /" patterns (with optional flags like --chown)
+            let parts: Vec<&str> = trimmed.split_whitespace().collect();
+            // Find the source and dest, skipping flags (start with --)
+            let non_flag_parts: Vec<&str> = parts[1..]
+                .iter()
+                .filter(|p| !p.starts_with("--"))
+                .copied()
+                .collect();
+
+            if non_flag_parts.len() >= 2 && non_flag_parts[0] == "." && !has_dockerignore {
+                findings.push(
+                    Finding::new(
+                        "DOCKER008",
+                        "docker",
+                        Severity::Info,
+                        "COPY with entire build context used without .dockerignore",
+                    )
+                    .with_location(format!("{}:{}", dockerfile_path, line_num + 1))
+                    .with_description(
+                        "Using 'COPY . .' copies the entire build context into the image. \
+                         Without a .dockerignore file, this may include unnecessary files \
+                         like .git, node_modules, or sensitive data.",
+                    )
+                    .with_remediation(
+                        "Create a .dockerignore file to exclude unnecessary files, or use \
+                         more specific COPY instructions.",
+                    ),
+                );
+            }
+        }
+    }
+
+    Ok(findings)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::Config;
+    use crate::scanner::Scanner;
+    use std::fs;
+    use tempfile::TempDir;
+
+    // --- DOCKER001: Dockerfile presence ---
+
+    #[tokio::test]
+    async fn test_docker001_missing_dockerfile_with_compose() {
+        let temp_dir = TempDir::new().unwrap();
+        let root = temp_dir.path();
+
+        fs::write(root.join("docker-compose.yml"), "version: '3'").unwrap();
+
+        let scanner = Scanner::new(root.to_path_buf());
+        let findings = check_dockerfile_presence(&scanner).await.unwrap();
+
+        assert!(findings.iter().any(|f| f.rule_id == "DOCKER001"));
+    }
+
+    #[tokio::test]
+    async fn test_docker001_missing_dockerfile_with_dockerignore() {
+        let temp_dir = TempDir::new().unwrap();
+        let root = temp_dir.path();
+
+        fs::write(root.join(".dockerignore"), "node_modules\n.git").unwrap();
+
+        let scanner = Scanner::new(root.to_path_buf());
+        let findings = check_dockerfile_presence(&scanner).await.unwrap();
+
+        assert!(findings.iter().any(|f| f.rule_id == "DOCKER001"));
+    }
+
+    #[tokio::test]
+    async fn test_docker001_no_finding_when_dockerfile_exists() {
+        let temp_dir = TempDir::new().unwrap();
+        let root = temp_dir.path();
+
+        fs::write(root.join("Dockerfile"), "FROM ubuntu:22.04").unwrap();
+        fs::write(root.join("docker-compose.yml"), "version: '3'").unwrap();
+
+        let scanner = Scanner::new(root.to_path_buf());
+        let findings = check_dockerfile_presence(&scanner).await.unwrap();
+
+        assert!(findings.is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_docker001_no_finding_when_no_docker_files() {
+        let temp_dir = TempDir::new().unwrap();
+        let root = temp_dir.path();
+
+        fs::write(root.join("README.md"), "# Project").unwrap();
+
+        let scanner = Scanner::new(root.to_path_buf());
+        let findings = check_dockerfile_presence(&scanner).await.unwrap();
+
+        assert!(findings.is_empty());
+    }
+
+    // --- DOCKER002: .dockerignore ---
+
+    #[tokio::test]
+    async fn test_docker002_missing_dockerignore() {
+        let temp_dir = TempDir::new().unwrap();
+        let root = temp_dir.path();
+
+        fs::write(root.join("Dockerfile"), "FROM ubuntu:22.04").unwrap();
+
+        let scanner = Scanner::new(root.to_path_buf());
+        let findings = check_dockerignore(&scanner).await.unwrap();
+
+        assert!(findings.iter().any(|f| f.rule_id == "DOCKER002"));
+    }
+
+    #[tokio::test]
+    async fn test_docker002_no_finding_with_dockerignore() {
+        let temp_dir = TempDir::new().unwrap();
+        let root = temp_dir.path();
+
+        fs::write(root.join("Dockerfile"), "FROM ubuntu:22.04").unwrap();
+        fs::write(root.join(".dockerignore"), ".git\nnode_modules").unwrap();
+
+        let scanner = Scanner::new(root.to_path_buf());
+        let findings = check_dockerignore(&scanner).await.unwrap();
+
+        assert!(findings.is_empty());
+    }
+
+    // --- DOCKER003: Pinned tags ---
+
+    #[tokio::test]
+    async fn test_docker003_unpinned_from() {
+        let temp_dir = TempDir::new().unwrap();
+        let root = temp_dir.path();
+
+        fs::write(root.join("Dockerfile"), "FROM ubuntu\nRUN apt-get update").unwrap();
+
+        let scanner = Scanner::new(root.to_path_buf());
+        let findings = check_pinned_tag(&scanner).await.unwrap();
+
+        assert!(findings.iter().any(|f| f.rule_id == "DOCKER003"));
+        assert!(findings.iter().any(|f| f.severity == Severity::Critical));
+    }
+
+    #[tokio::test]
+    async fn test_docker003_latest_tag() {
+        let temp_dir = TempDir::new().unwrap();
+        let root = temp_dir.path();
+
+        fs::write(root.join("Dockerfile"), "FROM node:latest\nRUN npm install").unwrap();
+
+        let scanner = Scanner::new(root.to_path_buf());
+        let findings = check_pinned_tag(&scanner).await.unwrap();
+
+        assert!(findings
+            .iter()
+            .any(|f| f.rule_id == "DOCKER003" && f.message.contains("latest")));
+    }
+
+    #[tokio::test]
+    async fn test_docker003_pinned_tag_no_finding() {
+        let temp_dir = TempDir::new().unwrap();
+        let root = temp_dir.path();
+
+        fs::write(
+            root.join("Dockerfile"),
+            "FROM node:20-alpine AS builder\nFROM nginx:1.25-alpine\nCOPY --from=builder /app /usr/share/nginx/html",
+        )
+        .unwrap();
+
+        let scanner = Scanner::new(root.to_path_buf());
+        let findings = check_pinned_tag(&scanner).await.unwrap();
+
+        assert!(
+            findings.is_empty(),
+            "Expected no findings for pinned tags, got: {:?}",
+            findings.iter().map(|f| &f.message).collect::<Vec<_>>()
+        );
+    }
+
+    #[tokio::test]
+    async fn test_docker003_scratch_no_finding() {
+        let temp_dir = TempDir::new().unwrap();
+        let root = temp_dir.path();
+
+        fs::write(
+            root.join("Dockerfile"),
+            "FROM golang:1.21 AS builder\nRUN go build\nFROM scratch\nCOPY --from=builder /app /app",
+        )
+        .unwrap();
+
+        let scanner = Scanner::new(root.to_path_buf());
+        let findings = check_pinned_tag(&scanner).await.unwrap();
+
+        // scratch should not trigger, but golang:1.21 is pinned so no findings
+        assert!(findings.is_empty());
+    }
+
+    // --- DOCKER004: USER instruction ---
+
+    #[tokio::test]
+    async fn test_docker004_no_user() {
+        let temp_dir = TempDir::new().unwrap();
+        let root = temp_dir.path();
+
+        fs::write(
+            root.join("Dockerfile"),
+            "FROM ubuntu:22.04\nRUN apt-get update\nCMD [\"bash\"]",
+        )
+        .unwrap();
+
+        let scanner = Scanner::new(root.to_path_buf());
+        let findings = check_user_instruction(&scanner).await.unwrap();
+
+        assert!(findings.iter().any(|f| f.rule_id == "DOCKER004"));
+    }
+
+    #[tokio::test]
+    async fn test_docker004_has_user() {
+        let temp_dir = TempDir::new().unwrap();
+        let root = temp_dir.path();
+
+        fs::write(
+            root.join("Dockerfile"),
+            "FROM ubuntu:22.04\nRUN useradd -m app\nUSER app\nCMD [\"bash\"]",
+        )
+        .unwrap();
+
+        let scanner = Scanner::new(root.to_path_buf());
+        let findings = check_user_instruction(&scanner).await.unwrap();
+
+        assert!(findings.is_empty());
+    }
+
+    // --- DOCKER005: HEALTHCHECK ---
+
+    #[tokio::test]
+    async fn test_docker005_no_healthcheck() {
+        let temp_dir = TempDir::new().unwrap();
+        let root = temp_dir.path();
+
+        fs::write(root.join("Dockerfile"), "FROM ubuntu:22.04\nCMD [\"bash\"]").unwrap();
+
+        let scanner = Scanner::new(root.to_path_buf());
+        let findings = check_healthcheck(&scanner).await.unwrap();
+
+        assert!(findings.iter().any(|f| f.rule_id == "DOCKER005"));
+    }
+
+    #[tokio::test]
+    async fn test_docker005_has_healthcheck() {
+        let temp_dir = TempDir::new().unwrap();
+        let root = temp_dir.path();
+
+        fs::write(
+            root.join("Dockerfile"),
+            "FROM ubuntu:22.04\nHEALTHCHECK CMD curl -f http://localhost/ || exit 1\nCMD [\"bash\"]",
+        )
+        .unwrap();
+
+        let scanner = Scanner::new(root.to_path_buf());
+        let findings = check_healthcheck(&scanner).await.unwrap();
+
+        assert!(findings.is_empty());
+    }
+
+    // --- DOCKER006: Multi-stage build ---
+
+    #[tokio::test]
+    async fn test_docker006_single_stage() {
+        let temp_dir = TempDir::new().unwrap();
+        let root = temp_dir.path();
+
+        fs::write(
+            root.join("Dockerfile"),
+            "FROM ubuntu:22.04\nRUN apt-get update\nCMD [\"bash\"]",
+        )
+        .unwrap();
+
+        let scanner = Scanner::new(root.to_path_buf());
+        let findings = check_multi_stage(&scanner).await.unwrap();
+
+        assert!(findings.iter().any(|f| f.rule_id == "DOCKER006"));
+        assert!(findings.iter().any(|f| f.severity == Severity::Info));
+    }
+
+    #[tokio::test]
+    async fn test_docker006_multi_stage_no_finding() {
+        let temp_dir = TempDir::new().unwrap();
+        let root = temp_dir.path();
+
+        fs::write(
+            root.join("Dockerfile"),
+            "FROM node:20 AS builder\nRUN npm install\nFROM nginx:1.25\nCOPY --from=builder /app /usr/share/nginx/html",
+        )
+        .unwrap();
+
+        let scanner = Scanner::new(root.to_path_buf());
+        let findings = check_multi_stage(&scanner).await.unwrap();
+
+        assert!(findings.is_empty());
+    }
+
+    // --- DOCKER007: Secrets in ENV/ARG ---
+
+    #[tokio::test]
+    async fn test_docker007_secret_in_env() {
+        let temp_dir = TempDir::new().unwrap();
+        let root = temp_dir.path();
+
+        fs::write(
+            root.join("Dockerfile"),
+            "FROM ubuntu:22.04\nENV DB_PASSWORD=mysecret\nCMD [\"bash\"]",
+        )
+        .unwrap();
+
+        let scanner = Scanner::new(root.to_path_buf());
+        let findings = check_secrets_in_env(&scanner).await.unwrap();
+
+        assert!(findings.iter().any(|f| f.rule_id == "DOCKER007"));
+    }
+
+    #[tokio::test]
+    async fn test_docker007_secret_in_arg() {
+        let temp_dir = TempDir::new().unwrap();
+        let root = temp_dir.path();
+
+        fs::write(
+            root.join("Dockerfile"),
+            "FROM ubuntu:22.04\nARG API_KEY=abc123\nCMD [\"bash\"]",
+        )
+        .unwrap();
+
+        let scanner = Scanner::new(root.to_path_buf());
+        let findings = check_secrets_in_env(&scanner).await.unwrap();
+
+        assert!(findings.iter().any(|f| f.rule_id == "DOCKER007"));
+    }
+
+    #[tokio::test]
+    async fn test_docker007_no_secrets() {
+        let temp_dir = TempDir::new().unwrap();
+        let root = temp_dir.path();
+
+        fs::write(
+            root.join("Dockerfile"),
+            "FROM ubuntu:22.04\nENV APP_PORT=8080\nENV NODE_ENV=production\nCMD [\"bash\"]",
+        )
+        .unwrap();
+
+        let scanner = Scanner::new(root.to_path_buf());
+        let findings = check_secrets_in_env(&scanner).await.unwrap();
+
+        assert!(findings.is_empty());
+    }
+
+    // --- DOCKER008: COPY . . without .dockerignore ---
+
+    #[tokio::test]
+    async fn test_docker008_copy_all_without_dockerignore() {
+        let temp_dir = TempDir::new().unwrap();
+        let root = temp_dir.path();
+
+        fs::write(
+            root.join("Dockerfile"),
+            "FROM ubuntu:22.04\nCOPY . .\nCMD [\"bash\"]",
+        )
+        .unwrap();
+
+        let scanner = Scanner::new(root.to_path_buf());
+        let findings = check_copy_all(&scanner).await.unwrap();
+
+        assert!(findings.iter().any(|f| f.rule_id == "DOCKER008"));
+    }
+
+    #[tokio::test]
+    async fn test_docker008_copy_all_with_dockerignore_no_finding() {
+        let temp_dir = TempDir::new().unwrap();
+        let root = temp_dir.path();
+
+        fs::write(
+            root.join("Dockerfile"),
+            "FROM ubuntu:22.04\nCOPY . .\nCMD [\"bash\"]",
+        )
+        .unwrap();
+        fs::write(root.join(".dockerignore"), ".git\nnode_modules").unwrap();
+
+        let scanner = Scanner::new(root.to_path_buf());
+        let findings = check_copy_all(&scanner).await.unwrap();
+
+        assert!(findings.is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_docker008_specific_copy_no_finding() {
+        let temp_dir = TempDir::new().unwrap();
+        let root = temp_dir.path();
+
+        fs::write(
+            root.join("Dockerfile"),
+            "FROM ubuntu:22.04\nCOPY src/ /app/src/\nCMD [\"bash\"]",
+        )
+        .unwrap();
+
+        let scanner = Scanner::new(root.to_path_buf());
+        let findings = check_copy_all(&scanner).await.unwrap();
+
+        assert!(findings.is_empty());
+    }
+
+    // --- Integration: RuleCategory trait ---
+
+    #[tokio::test]
+    async fn test_docker_rules_category_name() {
+        let rules = DockerRules;
+        assert_eq!(rules.name(), "docker");
+    }
+
+    #[tokio::test]
+    async fn test_docker_rules_run_integration() {
+        let temp_dir = TempDir::new().unwrap();
+        let root = temp_dir.path();
+
+        // Create a Dockerfile with multiple issues
+        fs::write(
+            root.join("Dockerfile"),
+            "FROM ubuntu\nENV SECRET_TOKEN=abc\nCOPY . .\nCMD [\"bash\"]",
+        )
+        .unwrap();
+
+        let scanner = Scanner::new(root.to_path_buf());
+        let config = Config::default();
+        let rules = DockerRules;
+
+        let findings = rules.run(&scanner, &config).await.unwrap();
+
+        // Should find multiple issues: no dockerignore, unpinned tag, no USER,
+        // no HEALTHCHECK, single stage, secrets in ENV, COPY . . without dockerignore
+        let rule_ids: Vec<&str> = findings.iter().map(|f| f.rule_id.as_str()).collect();
+        assert!(
+            rule_ids.contains(&"DOCKER002"),
+            "Should find DOCKER002 (no .dockerignore)"
+        );
+        assert!(
+            rule_ids.contains(&"DOCKER003"),
+            "Should find DOCKER003 (unpinned FROM)"
+        );
+        assert!(
+            rule_ids.contains(&"DOCKER004"),
+            "Should find DOCKER004 (no USER)"
+        );
+        assert!(
+            rule_ids.contains(&"DOCKER005"),
+            "Should find DOCKER005 (no HEALTHCHECK)"
+        );
+        assert!(
+            rule_ids.contains(&"DOCKER006"),
+            "Should find DOCKER006 (single stage)"
+        );
+        assert!(
+            rule_ids.contains(&"DOCKER007"),
+            "Should find DOCKER007 (secret in ENV)"
+        );
+        assert!(
+            rule_ids.contains(&"DOCKER008"),
+            "Should find DOCKER008 (COPY . . without .dockerignore)"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_docker003_copy_with_flags() {
+        let temp_dir = TempDir::new().unwrap();
+        let root = temp_dir.path();
+
+        fs::write(
+            root.join("Dockerfile"),
+            "FROM ubuntu:22.04\nCOPY --chown=1000:1000 . /app\nCMD [\"bash\"]",
+        )
+        .unwrap();
+
+        let scanner = Scanner::new(root.to_path_buf());
+        let findings = check_copy_all(&scanner).await.unwrap();
+
+        // "." is the source and "/app" is the dest - should trigger without .dockerignore
+        assert!(findings.iter().any(|f| f.rule_id == "DOCKER008"));
+    }
+}

--- a/src/rules/categories/docs.rs
+++ b/src/rules/categories/docs.rs
@@ -6,6 +6,7 @@
 //! - CONTRIBUTING guidelines
 //! - CODE_OF_CONDUCT files
 //! - SECURITY policy files
+//! - CHANGELOG presence and format
 
 use crate::error::RepoLensError;
 
@@ -62,6 +63,21 @@ impl RuleCategory for DocsRules {
             findings.extend(check_security(scanner).await?);
         }
 
+        // Check CHANGELOG
+        if config.is_rule_enabled("docs/changelog") {
+            findings.extend(check_changelog(scanner).await?);
+        }
+
+        // Check CHANGELOG format
+        if config.is_rule_enabled("docs/changelog-format") {
+            findings.extend(check_changelog_format(scanner).await?);
+        }
+
+        // Check CHANGELOG unreleased section
+        if config.is_rule_enabled("docs/changelog-unreleased") {
+            findings.extend(check_changelog_unreleased(scanner).await?);
+        }
+
         Ok(findings)
     }
 }
@@ -93,11 +109,11 @@ async fn check_readme(scanner: &Scanner) -> Result<Vec<Finding>, RepoLensError> 
                 "README file is missing",
             )
             .with_description(
-                "A README file is essential for explaining what the project does and how to use it."
+                "A README file is essential for explaining what the project does and how to use it.",
             )
             .with_remediation(
-                "Create a README.md file with project description, installation instructions, and usage examples."
-            )
+                "Create a README.md file with project description, installation instructions, and usage examples.",
+            ),
         );
         return Ok(findings);
     }
@@ -115,8 +131,8 @@ async fn check_readme(scanner: &Scanner) -> Result<Vec<Finding>, RepoLensError> 
                     format!("README is too short ({} lines)", line_count),
                 )
                 .with_description(
-                    "A comprehensive README should include sections for description, installation, usage, and contribution guidelines."
-                )
+                    "A comprehensive README should include sections for description, installation, usage, and contribution guidelines.",
+                ),
             );
         }
 
@@ -174,11 +190,11 @@ async fn check_license(scanner: &Scanner, config: &Config) -> Result<Vec<Finding
                 "LICENSE file is missing",
             )
             .with_description(
-                "A LICENSE file is required for open source projects to define how others can use your code."
+                "A LICENSE file is required for open source projects to define how others can use your code.",
             )
             .with_remediation(
-                "Add a LICENSE file with an appropriate open source license (MIT, Apache-2.0, GPL-3.0, etc.)."
-            )
+                "Add a LICENSE file with an appropriate open source license (MIT, Apache-2.0, GPL-3.0, etc.).",
+            ),
         );
     }
 
@@ -211,11 +227,11 @@ async fn check_contributing(scanner: &Scanner) -> Result<Vec<Finding>, RepoLensE
                 "CONTRIBUTING file is missing",
             )
             .with_description(
-                "A CONTRIBUTING file helps potential contributors understand how to participate in your project."
+                "A CONTRIBUTING file helps potential contributors understand how to participate in your project.",
             )
             .with_remediation(
-                "Create a CONTRIBUTING.md file with contribution guidelines, code style, and pull request process."
-            )
+                "Create a CONTRIBUTING.md file with contribution guidelines, code style, and pull request process.",
+            ),
         );
     }
 
@@ -252,11 +268,11 @@ async fn check_code_of_conduct(scanner: &Scanner) -> Result<Vec<Finding>, RepoLe
                 "CODE_OF_CONDUCT file is missing",
             )
             .with_description(
-                "A Code of Conduct establishes expectations for behavior and helps create a welcoming community."
+                "A Code of Conduct establishes expectations for behavior and helps create a welcoming community.",
             )
             .with_remediation(
-                "Add a CODE_OF_CONDUCT.md file. Consider using the Contributor Covenant as a starting point."
-            )
+                "Add a CODE_OF_CONDUCT.md file. Consider using the Contributor Covenant as a starting point.",
+            ),
         );
     }
 
@@ -289,12 +305,178 @@ async fn check_security(scanner: &Scanner) -> Result<Vec<Finding>, RepoLensError
                 "SECURITY policy file is missing",
             )
             .with_description(
-                "A SECURITY.md file tells users how to report security vulnerabilities responsibly."
+                "A SECURITY.md file tells users how to report security vulnerabilities responsibly.",
             )
             .with_remediation(
-                "Create a SECURITY.md file with instructions for reporting security issues."
-            )
+                "Create a SECURITY.md file with instructions for reporting security issues.",
+            ),
         );
+    }
+
+    Ok(findings)
+}
+
+/// Find the changelog file path if it exists
+///
+/// Checks for common changelog file names.
+///
+/// # Arguments
+///
+/// * `scanner` - The scanner to access repository files
+///
+/// # Returns
+///
+/// The path to the changelog file, or None if not found
+fn find_changelog(scanner: &Scanner) -> Option<&'static str> {
+    let changelog_files = [
+        "CHANGELOG.md",
+        "CHANGELOG",
+        "CHANGELOG.txt",
+        "HISTORY.md",
+        "CHANGES.md",
+    ];
+    changelog_files.into_iter().find(|f| scanner.file_exists(f))
+}
+
+/// Check for CHANGELOG file
+///
+/// Verifies that a CHANGELOG file exists.
+///
+/// # Arguments
+///
+/// * `scanner` - The scanner to access repository files
+///
+/// # Returns
+///
+/// A vector of findings for missing CHANGELOG
+async fn check_changelog(scanner: &Scanner) -> Result<Vec<Finding>, RepoLensError> {
+    let mut findings = Vec::new();
+
+    if find_changelog(scanner).is_none() {
+        findings.push(
+            Finding::new(
+                "DOC008",
+                "docs",
+                Severity::Warning,
+                "CHANGELOG file is missing",
+            )
+            .with_description(
+                "A CHANGELOG file helps users and contributors track notable changes between releases.",
+            )
+            .with_remediation(
+                "Create a CHANGELOG.md file. Consider following the Keep a Changelog format (https://keepachangelog.com).",
+            ),
+        );
+    }
+
+    Ok(findings)
+}
+
+/// Check if CHANGELOG follows Keep a Changelog format
+///
+/// Looks for semver version patterns like `## [x.y.z]` in the changelog.
+///
+/// # Arguments
+///
+/// * `scanner` - The scanner to access repository files
+///
+/// # Returns
+///
+/// A vector of findings for non-standard changelog format
+async fn check_changelog_format(scanner: &Scanner) -> Result<Vec<Finding>, RepoLensError> {
+    let mut findings = Vec::new();
+
+    if let Some(changelog_path) = find_changelog(scanner) {
+        if let Ok(content) = scanner.read_file(changelog_path) {
+            // Look for ## [x.y.z] pattern (Keep a Changelog format)
+            let has_semver_headers = content.lines().any(|line| {
+                let trimmed = line.trim();
+                trimmed.starts_with("## [")
+                    && trimmed.contains('.')
+                    && (trimmed.contains(']') || trimmed.ends_with(']'))
+            });
+
+            if !has_semver_headers {
+                findings.push(
+                    Finding::new(
+                        "DOC009",
+                        "docs",
+                        Severity::Info,
+                        "CHANGELOG does not follow Keep a Changelog format",
+                    )
+                    .with_location(changelog_path)
+                    .with_description(
+                        "The Keep a Changelog format uses '## [x.y.z]' headers for each version, making it easier to parse and read.",
+                    )
+                    .with_remediation(
+                        "Consider reformatting your CHANGELOG to follow Keep a Changelog (https://keepachangelog.com).",
+                    ),
+                );
+            }
+        }
+    }
+
+    Ok(findings)
+}
+
+/// Check if CHANGELOG has content in the Unreleased section
+///
+/// If an `## [Unreleased]` section exists, checks whether it has content.
+///
+/// # Arguments
+///
+/// * `scanner` - The scanner to access repository files
+///
+/// # Returns
+///
+/// A vector of findings for empty Unreleased section
+async fn check_changelog_unreleased(scanner: &Scanner) -> Result<Vec<Finding>, RepoLensError> {
+    let mut findings = Vec::new();
+
+    if let Some(changelog_path) = find_changelog(scanner) {
+        if let Ok(content) = scanner.read_file(changelog_path) {
+            let lines: Vec<&str> = content.lines().collect();
+
+            // Find ## [Unreleased] section
+            let unreleased_idx = lines.iter().position(|line| {
+                let trimmed = line.trim().to_lowercase();
+                trimmed.starts_with("## [unreleased]") || trimmed == "## [unreleased]"
+            });
+
+            if let Some(idx) = unreleased_idx {
+                // Find the next ## [ section
+                let next_section_idx = lines
+                    .iter()
+                    .skip(idx + 1)
+                    .position(|line| line.trim().starts_with("## ["))
+                    .map(|pos| pos + idx + 1);
+
+                let end = next_section_idx.unwrap_or(lines.len());
+
+                // Check if there's any non-empty content between Unreleased header and next section
+                let has_content = lines[idx + 1..end]
+                    .iter()
+                    .any(|line| !line.trim().is_empty());
+
+                if !has_content {
+                    findings.push(
+                        Finding::new(
+                            "DOC010",
+                            "docs",
+                            Severity::Info,
+                            "CHANGELOG has empty Unreleased section",
+                        )
+                        .with_location(changelog_path)
+                        .with_description(
+                            "The [Unreleased] section in the CHANGELOG is empty. Consider adding pending changes or removing the section until there are changes to document.",
+                        )
+                        .with_remediation(
+                            "Add pending changes to the [Unreleased] section or remove it until there are changes to document.",
+                        ),
+                    );
+                }
+            }
+        }
     }
 
     Ok(findings)
@@ -410,5 +592,188 @@ mod tests {
 
         assert!(!findings.is_empty());
         assert!(findings.iter().any(|f| f.rule_id == "DOC007"));
+    }
+
+    // ===== DOC008: CHANGELOG Tests =====
+
+    #[tokio::test]
+    async fn test_check_changelog_missing() {
+        let temp_dir = TempDir::new().unwrap();
+        let root = temp_dir.path();
+
+        let scanner = Scanner::new(root.to_path_buf());
+        let findings = check_changelog(&scanner).await.unwrap();
+
+        assert!(!findings.is_empty());
+        assert!(findings.iter().any(|f| f.rule_id == "DOC008"));
+    }
+
+    #[tokio::test]
+    async fn test_check_changelog_present() {
+        let temp_dir = TempDir::new().unwrap();
+        let root = temp_dir.path();
+        fs::write(
+            root.join("CHANGELOG.md"),
+            "# Changelog\n\n## [1.0.0]\n\n- Initial release",
+        )
+        .unwrap();
+
+        let scanner = Scanner::new(root.to_path_buf());
+        let findings = check_changelog(&scanner).await.unwrap();
+
+        assert!(findings.iter().all(|f| f.rule_id != "DOC008"));
+    }
+
+    #[tokio::test]
+    async fn test_check_changelog_present_as_history() {
+        let temp_dir = TempDir::new().unwrap();
+        let root = temp_dir.path();
+        fs::write(
+            root.join("HISTORY.md"),
+            "# History\n\n## 1.0.0\n\n- First release",
+        )
+        .unwrap();
+
+        let scanner = Scanner::new(root.to_path_buf());
+        let findings = check_changelog(&scanner).await.unwrap();
+
+        assert!(findings.iter().all(|f| f.rule_id != "DOC008"));
+    }
+
+    #[tokio::test]
+    async fn test_check_changelog_present_as_changes() {
+        let temp_dir = TempDir::new().unwrap();
+        let root = temp_dir.path();
+        fs::write(root.join("CHANGES.md"), "# Changes").unwrap();
+
+        let scanner = Scanner::new(root.to_path_buf());
+        let findings = check_changelog(&scanner).await.unwrap();
+
+        assert!(findings.iter().all(|f| f.rule_id != "DOC008"));
+    }
+
+    // ===== DOC009: CHANGELOG Format Tests =====
+
+    #[tokio::test]
+    async fn test_check_changelog_format_valid() {
+        let temp_dir = TempDir::new().unwrap();
+        let root = temp_dir.path();
+        fs::write(
+            root.join("CHANGELOG.md"),
+            "# Changelog\n\n## [Unreleased]\n\n## [1.0.0] - 2024-01-01\n\n### Added\n- Initial release\n",
+        )
+        .unwrap();
+
+        let scanner = Scanner::new(root.to_path_buf());
+        let findings = check_changelog_format(&scanner).await.unwrap();
+
+        assert!(findings.iter().all(|f| f.rule_id != "DOC009"));
+    }
+
+    #[tokio::test]
+    async fn test_check_changelog_format_invalid() {
+        let temp_dir = TempDir::new().unwrap();
+        let root = temp_dir.path();
+        fs::write(
+            root.join("CHANGELOG.md"),
+            "# Changelog\n\nJust some text about what changed.\nNo structured headers here.\n",
+        )
+        .unwrap();
+
+        let scanner = Scanner::new(root.to_path_buf());
+        let findings = check_changelog_format(&scanner).await.unwrap();
+
+        assert!(findings.iter().any(|f| f.rule_id == "DOC009"));
+    }
+
+    #[tokio::test]
+    async fn test_check_changelog_format_no_changelog() {
+        let temp_dir = TempDir::new().unwrap();
+        let root = temp_dir.path();
+
+        let scanner = Scanner::new(root.to_path_buf());
+        let findings = check_changelog_format(&scanner).await.unwrap();
+
+        // No changelog file means no DOC009 finding
+        assert!(findings.iter().all(|f| f.rule_id != "DOC009"));
+    }
+
+    // ===== DOC010: CHANGELOG Unreleased Tests =====
+
+    #[tokio::test]
+    async fn test_check_changelog_unreleased_with_content() {
+        let temp_dir = TempDir::new().unwrap();
+        let root = temp_dir.path();
+        fs::write(
+            root.join("CHANGELOG.md"),
+            "# Changelog\n\n## [Unreleased]\n\n### Added\n- New feature\n\n## [1.0.0] - 2024-01-01\n\n- Initial release\n",
+        )
+        .unwrap();
+
+        let scanner = Scanner::new(root.to_path_buf());
+        let findings = check_changelog_unreleased(&scanner).await.unwrap();
+
+        assert!(findings.iter().all(|f| f.rule_id != "DOC010"));
+    }
+
+    #[tokio::test]
+    async fn test_check_changelog_unreleased_empty() {
+        let temp_dir = TempDir::new().unwrap();
+        let root = temp_dir.path();
+        fs::write(
+            root.join("CHANGELOG.md"),
+            "# Changelog\n\n## [Unreleased]\n\n## [1.0.0] - 2024-01-01\n\n- Initial release\n",
+        )
+        .unwrap();
+
+        let scanner = Scanner::new(root.to_path_buf());
+        let findings = check_changelog_unreleased(&scanner).await.unwrap();
+
+        assert!(findings.iter().any(|f| f.rule_id == "DOC010"));
+    }
+
+    #[tokio::test]
+    async fn test_check_changelog_unreleased_no_unreleased_section() {
+        let temp_dir = TempDir::new().unwrap();
+        let root = temp_dir.path();
+        fs::write(
+            root.join("CHANGELOG.md"),
+            "# Changelog\n\n## [1.0.0] - 2024-01-01\n\n- Initial release\n",
+        )
+        .unwrap();
+
+        let scanner = Scanner::new(root.to_path_buf());
+        let findings = check_changelog_unreleased(&scanner).await.unwrap();
+
+        // No Unreleased section, so no DOC010 finding
+        assert!(findings.iter().all(|f| f.rule_id != "DOC010"));
+    }
+
+    #[tokio::test]
+    async fn test_check_changelog_unreleased_no_changelog() {
+        let temp_dir = TempDir::new().unwrap();
+        let root = temp_dir.path();
+
+        let scanner = Scanner::new(root.to_path_buf());
+        let findings = check_changelog_unreleased(&scanner).await.unwrap();
+
+        // No changelog file means no DOC010 finding
+        assert!(findings.iter().all(|f| f.rule_id != "DOC010"));
+    }
+
+    #[tokio::test]
+    async fn test_check_changelog_unreleased_at_end_of_file_empty() {
+        let temp_dir = TempDir::new().unwrap();
+        let root = temp_dir.path();
+        fs::write(
+            root.join("CHANGELOG.md"),
+            "# Changelog\n\n## [1.0.0] - 2024-01-01\n\n- Initial release\n\n## [Unreleased]\n",
+        )
+        .unwrap();
+
+        let scanner = Scanner::new(root.to_path_buf());
+        let findings = check_changelog_unreleased(&scanner).await.unwrap();
+
+        assert!(findings.iter().any(|f| f.rule_id == "DOC010"));
     }
 }

--- a/src/rules/categories/mod.rs
+++ b/src/rules/categories/mod.rs
@@ -2,6 +2,7 @@
 
 pub mod custom;
 pub mod dependencies;
+pub mod docker;
 pub mod docs;
 pub mod files;
 pub mod licenses;

--- a/src/rules/categories/quality.rs
+++ b/src/rules/categories/quality.rs
@@ -4,6 +4,11 @@
 //! - Test files and directories
 //! - Linting configuration
 //! - Editor configuration files
+//! - Code coverage configuration
+//! - API documentation
+//! - Complexity analysis tools
+//! - Dead code detection tools
+//! - Naming convention enforcement
 
 use crate::error::RepoLensError;
 
@@ -11,6 +16,7 @@ use crate::config::Config;
 use crate::rules::engine::RuleCategory;
 use crate::rules::results::{Finding, Severity};
 use crate::scanner::Scanner;
+use crate::utils::language_detection::{detect_languages, Language};
 
 /// Rules for checking code quality
 pub struct QualityRules;
@@ -50,6 +56,31 @@ impl RuleCategory for QualityRules {
             findings.extend(check_editorconfig(scanner).await?);
         }
 
+        // Check for coverage configuration
+        if config.is_rule_enabled("quality/coverage") {
+            findings.extend(check_coverage_config(scanner).await?);
+        }
+
+        // Check for API documentation
+        if config.is_rule_enabled("quality/api-docs") {
+            findings.extend(check_api_docs(scanner).await?);
+        }
+
+        // Check for complexity analysis configuration
+        if config.is_rule_enabled("quality/complexity") {
+            findings.extend(check_complexity_config(scanner).await?);
+        }
+
+        // Check for dead code detection
+        if config.is_rule_enabled("quality/dead-code") {
+            findings.extend(check_dead_code_config(scanner).await?);
+        }
+
+        // Check for naming convention enforcement
+        if config.is_rule_enabled("quality/naming-conventions") {
+            findings.extend(check_naming_conventions_config(scanner).await?);
+        }
+
         Ok(findings)
     }
 }
@@ -87,11 +118,11 @@ async fn check_tests(scanner: &Scanner) -> Result<Vec<Finding>, RepoLensError> {
                 "No tests detected",
             )
             .with_description(
-                "Tests are important for ensuring code quality and catching regressions."
+                "Tests are important for ensuring code quality and catching regressions.",
             )
             .with_remediation(
-                "Add tests to your project. Consider using a testing framework appropriate for your language."
-            )
+                "Add tests to your project. Consider using a testing framework appropriate for your language.",
+            ),
         );
     }
 
@@ -232,11 +263,380 @@ async fn check_editorconfig(scanner: &Scanner) -> Result<Vec<Finding>, RepoLensE
                 ".editorconfig file is missing",
             )
             .with_description(
-                "EditorConfig helps maintain consistent coding styles across different editors and IDEs."
+                "EditorConfig helps maintain consistent coding styles across different editors and IDEs.",
+            )
+            .with_remediation("Create a .editorconfig file to define coding style preferences."),
+        );
+    }
+
+    Ok(findings)
+}
+
+/// Check for code coverage configuration
+///
+/// Verifies that the repository has coverage tools configured, either via
+/// config files or CI workflow steps.
+///
+/// # Arguments
+///
+/// * `scanner` - The scanner to access repository files
+///
+/// # Returns
+///
+/// A vector of findings for missing coverage configuration
+async fn check_coverage_config(scanner: &Scanner) -> Result<Vec<Finding>, RepoLensError> {
+    let mut findings = Vec::new();
+
+    let coverage_files = [
+        "tarpaulin.toml",
+        ".coveragerc",
+        "codecov.yml",
+        ".codecov.yml",
+        ".nycrc",
+        ".nycrc.json",
+        ".coveralls.yml",
+        "jest.config.js",
+        "jest.config.ts",
+    ];
+
+    let has_coverage_file = coverage_files.iter().any(|f| scanner.file_exists(f));
+
+    // Check package.json for coverage config
+    let has_coverage_in_package_json = if scanner.file_exists("package.json") {
+        scanner
+            .read_file("package.json")
+            .map(|content| content.contains("coverage"))
+            .unwrap_or(false)
+    } else {
+        false
+    };
+
+    // Check CI workflows for coverage commands
+    let has_coverage_in_ci = if scanner.directory_exists(".github/workflows") {
+        scanner
+            .files_in_directory(".github/workflows")
+            .iter()
+            .filter(|f| f.path.ends_with(".yml") || f.path.ends_with(".yaml"))
+            .any(|file| {
+                scanner
+                    .read_file(&file.path)
+                    .map(|content| {
+                        let lower = content.to_lowercase();
+                        lower.contains("tarpaulin")
+                            || lower.contains("coverage")
+                            || lower.contains("codecov")
+                            || lower.contains("coveralls")
+                    })
+                    .unwrap_or(false)
+            })
+    } else {
+        false
+    };
+
+    if !has_coverage_file && !has_coverage_in_package_json && !has_coverage_in_ci {
+        let languages = detect_languages(scanner);
+        let suggestion = if languages.contains(&Language::Rust) {
+            "cargo-tarpaulin for Rust code coverage"
+        } else if languages.contains(&Language::JavaScript) {
+            "Jest coverage, nyc, or c8 for JavaScript/TypeScript code coverage"
+        } else if languages.contains(&Language::Python) {
+            "coverage.py or pytest-cov for Python code coverage"
+        } else if languages.contains(&Language::Go) {
+            "'go test -cover' for Go code coverage"
+        } else {
+            "a code coverage tool appropriate for your language"
+        };
+
+        findings.push(
+            Finding::new(
+                "QUALITY005",
+                "quality",
+                Severity::Info,
+                "No code coverage configuration detected",
+            )
+            .with_description(
+                "Code coverage helps identify untested code paths and improve test quality.",
+            )
+            .with_remediation(format!("Consider adding {}.", suggestion)),
+        );
+    }
+
+    Ok(findings)
+}
+
+/// Check for API documentation files
+///
+/// Verifies that API documentation exists (OpenAPI, Swagger, Typedoc, etc.).
+///
+/// # Arguments
+///
+/// * `scanner` - The scanner to access repository files
+///
+/// # Returns
+///
+/// A vector of findings for missing API documentation
+async fn check_api_docs(scanner: &Scanner) -> Result<Vec<Finding>, RepoLensError> {
+    let mut findings = Vec::new();
+
+    let api_doc_files = [
+        "openapi.yaml",
+        "openapi.yml",
+        "openapi.json",
+        "swagger.yaml",
+        "swagger.yml",
+        "swagger.json",
+        "typedoc.json",
+        ".typedoc.json",
+        "Doxyfile",
+    ];
+
+    let api_doc_dirs = ["api-docs", "docs/api"];
+
+    let has_api_docs = api_doc_files.iter().any(|f| scanner.file_exists(f))
+        || api_doc_dirs.iter().any(|d| scanner.directory_exists(d));
+
+    if !has_api_docs {
+        findings.push(
+            Finding::new(
+                "QUALITY006",
+                "quality",
+                Severity::Info,
+                "No API documentation detected",
+            )
+            .with_description(
+                "API documentation helps consumers understand and integrate with your project.",
             )
             .with_remediation(
-                "Create a .editorconfig file to define coding style preferences."
+                "Consider adding API documentation using OpenAPI/Swagger, Typedoc, or Doxygen.",
+            ),
+        );
+    }
+
+    Ok(findings)
+}
+
+/// Check for complexity analysis tool configuration
+///
+/// Verifies that complexity analysis tools are configured.
+///
+/// # Arguments
+///
+/// * `scanner` - The scanner to access repository files
+///
+/// # Returns
+///
+/// A vector of findings for missing complexity configuration
+async fn check_complexity_config(scanner: &Scanner) -> Result<Vec<Finding>, RepoLensError> {
+    let mut findings = Vec::new();
+
+    let mut has_complexity = false;
+
+    // Check for sonar-project.properties
+    if scanner.file_exists("sonar-project.properties") {
+        has_complexity = true;
+    }
+
+    // Check eslintrc files for complexity rule
+    if !has_complexity {
+        let eslint_files = [
+            ".eslintrc",
+            ".eslintrc.js",
+            ".eslintrc.json",
+            ".eslintrc.yml",
+            "eslint.config.js",
+        ];
+        for f in &eslint_files {
+            if scanner.file_exists(f) {
+                if let Ok(content) = scanner.read_file(f) {
+                    if content.contains("complexity") {
+                        has_complexity = true;
+                        break;
+                    }
+                }
+            }
+        }
+    }
+
+    // Check pylint config for max-complexity
+    if !has_complexity {
+        let pylint_files = [".pylintrc", "pyproject.toml", "setup.cfg"];
+        for f in &pylint_files {
+            if scanner.file_exists(f) {
+                if let Ok(content) = scanner.read_file(f) {
+                    if content.contains("max-complexity") {
+                        has_complexity = true;
+                        break;
+                    }
+                }
+            }
+        }
+    }
+
+    if !has_complexity {
+        findings.push(
+            Finding::new(
+                "QUALITY007",
+                "quality",
+                Severity::Info,
+                "No complexity analysis configuration detected",
             )
+            .with_description(
+                "Complexity analysis tools help identify overly complex code that may be hard to maintain.",
+            )
+            .with_remediation(
+                "Consider adding complexity rules to your linter or using SonarQube for complexity analysis.",
+            ),
+        );
+    }
+
+    Ok(findings)
+}
+
+/// Check for dead code detection tool configuration
+///
+/// Verifies that dead code detection tools are configured.
+///
+/// # Arguments
+///
+/// * `scanner` - The scanner to access repository files
+///
+/// # Returns
+///
+/// A vector of findings for missing dead code detection
+async fn check_dead_code_config(scanner: &Scanner) -> Result<Vec<Finding>, RepoLensError> {
+    let mut findings = Vec::new();
+
+    let mut has_dead_code_tool = false;
+
+    // Check for knip (JavaScript)
+    let knip_files = ["knip.json", "knip.config.ts", "knip.config.js"];
+    for f in &knip_files {
+        if scanner.file_exists(f) {
+            has_dead_code_tool = true;
+            break;
+        }
+    }
+
+    // Check package.json for knip
+    if !has_dead_code_tool && scanner.file_exists("package.json") {
+        if let Ok(content) = scanner.read_file("package.json") {
+            if content.contains("knip") {
+                has_dead_code_tool = true;
+            }
+        }
+    }
+
+    // Check Cargo.toml for dead code warnings
+    if !has_dead_code_tool && scanner.file_exists("Cargo.toml") {
+        if let Ok(content) = scanner.read_file("Cargo.toml") {
+            if content.contains("dead_code") || content.contains("unused") {
+                has_dead_code_tool = true;
+            }
+        }
+    }
+
+    // Check clippy.toml
+    if !has_dead_code_tool && scanner.file_exists("clippy.toml") {
+        if let Ok(content) = scanner.read_file("clippy.toml") {
+            if content.contains("unused") {
+                has_dead_code_tool = true;
+            }
+        }
+    }
+
+    if !has_dead_code_tool {
+        findings.push(
+            Finding::new(
+                "QUALITY008",
+                "quality",
+                Severity::Info,
+                "No dead code detection tool configured",
+            )
+            .with_description(
+                "Dead code detection tools help identify unused code that can be removed to improve maintainability.",
+            )
+            .with_remediation(
+                "Consider adding a dead code detection tool such as knip (JS/TS), vulture (Python), or enabling Rust dead_code warnings.",
+            ),
+        );
+    }
+
+    Ok(findings)
+}
+
+/// Check for naming convention enforcement configuration
+///
+/// Verifies that naming convention rules are configured in linters or editorconfig.
+///
+/// # Arguments
+///
+/// * `scanner` - The scanner to access repository files
+///
+/// # Returns
+///
+/// A vector of findings for missing naming convention enforcement
+async fn check_naming_conventions_config(scanner: &Scanner) -> Result<Vec<Finding>, RepoLensError> {
+    let mut findings = Vec::new();
+
+    let mut has_naming = false;
+
+    // Check eslintrc files for naming-convention rule
+    let eslint_files = [
+        ".eslintrc",
+        ".eslintrc.js",
+        ".eslintrc.json",
+        ".eslintrc.yml",
+        "eslint.config.js",
+    ];
+    for f in &eslint_files {
+        if scanner.file_exists(f) {
+            if let Ok(content) = scanner.read_file(f) {
+                if content.contains("naming-convention") {
+                    has_naming = true;
+                    break;
+                }
+            }
+        }
+    }
+
+    // Check pylintrc for naming-style
+    if !has_naming {
+        let pylint_files = [".pylintrc", "pyproject.toml", "setup.cfg"];
+        for f in &pylint_files {
+            if scanner.file_exists(f) {
+                if let Ok(content) = scanner.read_file(f) {
+                    if content.contains("naming-style") || content.contains("naming_style") {
+                        has_naming = true;
+                        break;
+                    }
+                }
+            }
+        }
+    }
+
+    // Check .editorconfig for naming rules
+    if !has_naming && scanner.file_exists(".editorconfig") {
+        if let Ok(content) = scanner.read_file(".editorconfig") {
+            if content.contains("file_header") || content.contains("dotnet_naming") {
+                has_naming = true;
+            }
+        }
+    }
+
+    if !has_naming {
+        findings.push(
+            Finding::new(
+                "QUALITY009",
+                "quality",
+                Severity::Info,
+                "No naming convention enforcement detected",
+            )
+            .with_description(
+                "Naming convention enforcement helps maintain consistent code style across the codebase.",
+            )
+            .with_remediation(
+                "Consider adding naming convention rules to your linter (e.g., @typescript-eslint/naming-convention, pylint naming-style).",
+            ),
         );
     }
 
@@ -432,5 +832,295 @@ mod tests {
 
         // Should have findings for missing tests and editorconfig
         assert!(!findings.is_empty());
+    }
+
+    // ===== QUALITY005: Coverage Config Tests =====
+
+    #[tokio::test]
+    async fn test_check_coverage_config_missing() {
+        let temp_dir = TempDir::new().unwrap();
+        let root = temp_dir.path();
+
+        let scanner = Scanner::new(root.to_path_buf());
+        let findings = check_coverage_config(&scanner).await.unwrap();
+
+        assert!(!findings.is_empty());
+        assert!(findings.iter().any(|f| f.rule_id == "QUALITY005"));
+    }
+
+    #[tokio::test]
+    async fn test_check_coverage_config_with_tarpaulin() {
+        let temp_dir = TempDir::new().unwrap();
+        let root = temp_dir.path();
+        fs::write(root.join("tarpaulin.toml"), "[report]\nout = [\"html\"]").unwrap();
+
+        let scanner = Scanner::new(root.to_path_buf());
+        let findings = check_coverage_config(&scanner).await.unwrap();
+
+        assert!(findings.iter().all(|f| f.rule_id != "QUALITY005"));
+    }
+
+    #[tokio::test]
+    async fn test_check_coverage_config_with_codecov_in_ci() {
+        let temp_dir = TempDir::new().unwrap();
+        let root = temp_dir.path();
+        let workflows_dir = root.join(".github").join("workflows");
+        fs::create_dir_all(&workflows_dir).unwrap();
+
+        fs::write(
+            workflows_dir.join("ci.yml"),
+            "name: CI\njobs:\n  test:\n    steps:\n      - uses: codecov/codecov-action@v4",
+        )
+        .unwrap();
+
+        let scanner = Scanner::new(root.to_path_buf());
+        let findings = check_coverage_config(&scanner).await.unwrap();
+
+        assert!(findings.iter().all(|f| f.rule_id != "QUALITY005"));
+    }
+
+    #[tokio::test]
+    async fn test_check_coverage_config_with_package_json_coverage() {
+        let temp_dir = TempDir::new().unwrap();
+        let root = temp_dir.path();
+        fs::write(
+            root.join("package.json"),
+            r#"{"name": "test", "scripts": {"test": "jest --coverage"}}"#,
+        )
+        .unwrap();
+
+        let scanner = Scanner::new(root.to_path_buf());
+        let findings = check_coverage_config(&scanner).await.unwrap();
+
+        assert!(findings.iter().all(|f| f.rule_id != "QUALITY005"));
+    }
+
+    // ===== QUALITY006: API Docs Tests =====
+
+    #[tokio::test]
+    async fn test_check_api_docs_missing() {
+        let temp_dir = TempDir::new().unwrap();
+        let root = temp_dir.path();
+
+        let scanner = Scanner::new(root.to_path_buf());
+        let findings = check_api_docs(&scanner).await.unwrap();
+
+        assert!(!findings.is_empty());
+        assert!(findings.iter().any(|f| f.rule_id == "QUALITY006"));
+    }
+
+    #[tokio::test]
+    async fn test_check_api_docs_with_openapi() {
+        let temp_dir = TempDir::new().unwrap();
+        let root = temp_dir.path();
+        fs::write(root.join("openapi.yaml"), "openapi: 3.0.0").unwrap();
+
+        let scanner = Scanner::new(root.to_path_buf());
+        let findings = check_api_docs(&scanner).await.unwrap();
+
+        assert!(findings.iter().all(|f| f.rule_id != "QUALITY006"));
+    }
+
+    #[tokio::test]
+    async fn test_check_api_docs_with_swagger() {
+        let temp_dir = TempDir::new().unwrap();
+        let root = temp_dir.path();
+        fs::write(root.join("swagger.json"), "{}").unwrap();
+
+        let scanner = Scanner::new(root.to_path_buf());
+        let findings = check_api_docs(&scanner).await.unwrap();
+
+        assert!(findings.iter().all(|f| f.rule_id != "QUALITY006"));
+    }
+
+    #[tokio::test]
+    async fn test_check_api_docs_with_directory() {
+        let temp_dir = TempDir::new().unwrap();
+        let root = temp_dir.path();
+        fs::create_dir_all(root.join("docs/api")).unwrap();
+        fs::write(root.join("docs/api/index.html"), "<html></html>").unwrap();
+
+        let scanner = Scanner::new(root.to_path_buf());
+        let findings = check_api_docs(&scanner).await.unwrap();
+
+        assert!(findings.iter().all(|f| f.rule_id != "QUALITY006"));
+    }
+
+    // ===== QUALITY007: Complexity Config Tests =====
+
+    #[tokio::test]
+    async fn test_check_complexity_config_missing() {
+        let temp_dir = TempDir::new().unwrap();
+        let root = temp_dir.path();
+
+        let scanner = Scanner::new(root.to_path_buf());
+        let findings = check_complexity_config(&scanner).await.unwrap();
+
+        assert!(!findings.is_empty());
+        assert!(findings.iter().any(|f| f.rule_id == "QUALITY007"));
+    }
+
+    #[tokio::test]
+    async fn test_check_complexity_config_with_sonar() {
+        let temp_dir = TempDir::new().unwrap();
+        let root = temp_dir.path();
+        fs::write(
+            root.join("sonar-project.properties"),
+            "sonar.projectKey=test",
+        )
+        .unwrap();
+
+        let scanner = Scanner::new(root.to_path_buf());
+        let findings = check_complexity_config(&scanner).await.unwrap();
+
+        assert!(findings.iter().all(|f| f.rule_id != "QUALITY007"));
+    }
+
+    #[tokio::test]
+    async fn test_check_complexity_config_with_eslint_complexity() {
+        let temp_dir = TempDir::new().unwrap();
+        let root = temp_dir.path();
+        fs::write(
+            root.join(".eslintrc.json"),
+            r#"{"rules": {"complexity": ["error", 10]}}"#,
+        )
+        .unwrap();
+
+        let scanner = Scanner::new(root.to_path_buf());
+        let findings = check_complexity_config(&scanner).await.unwrap();
+
+        assert!(findings.iter().all(|f| f.rule_id != "QUALITY007"));
+    }
+
+    #[tokio::test]
+    async fn test_check_complexity_config_with_pylint_max_complexity() {
+        let temp_dir = TempDir::new().unwrap();
+        let root = temp_dir.path();
+        fs::write(root.join(".pylintrc"), "[FORMAT]\nmax-complexity=10").unwrap();
+
+        let scanner = Scanner::new(root.to_path_buf());
+        let findings = check_complexity_config(&scanner).await.unwrap();
+
+        assert!(findings.iter().all(|f| f.rule_id != "QUALITY007"));
+    }
+
+    // ===== QUALITY008: Dead Code Config Tests =====
+
+    #[tokio::test]
+    async fn test_check_dead_code_config_missing() {
+        let temp_dir = TempDir::new().unwrap();
+        let root = temp_dir.path();
+
+        let scanner = Scanner::new(root.to_path_buf());
+        let findings = check_dead_code_config(&scanner).await.unwrap();
+
+        assert!(!findings.is_empty());
+        assert!(findings.iter().any(|f| f.rule_id == "QUALITY008"));
+    }
+
+    #[tokio::test]
+    async fn test_check_dead_code_config_with_knip() {
+        let temp_dir = TempDir::new().unwrap();
+        let root = temp_dir.path();
+        fs::write(root.join("knip.json"), r#"{"entry": ["src/index.ts"]}"#).unwrap();
+
+        let scanner = Scanner::new(root.to_path_buf());
+        let findings = check_dead_code_config(&scanner).await.unwrap();
+
+        assert!(findings.iter().all(|f| f.rule_id != "QUALITY008"));
+    }
+
+    #[tokio::test]
+    async fn test_check_dead_code_config_with_knip_in_package_json() {
+        let temp_dir = TempDir::new().unwrap();
+        let root = temp_dir.path();
+        fs::write(
+            root.join("package.json"),
+            r#"{"devDependencies": {"knip": "^5.0.0"}}"#,
+        )
+        .unwrap();
+
+        let scanner = Scanner::new(root.to_path_buf());
+        let findings = check_dead_code_config(&scanner).await.unwrap();
+
+        assert!(findings.iter().all(|f| f.rule_id != "QUALITY008"));
+    }
+
+    #[tokio::test]
+    async fn test_check_dead_code_config_with_cargo_unused() {
+        let temp_dir = TempDir::new().unwrap();
+        let root = temp_dir.path();
+        fs::write(
+            root.join("Cargo.toml"),
+            "[package]\nname = \"test\"\n\n[lints.rust]\nunused = \"warn\"",
+        )
+        .unwrap();
+
+        let scanner = Scanner::new(root.to_path_buf());
+        let findings = check_dead_code_config(&scanner).await.unwrap();
+
+        assert!(findings.iter().all(|f| f.rule_id != "QUALITY008"));
+    }
+
+    // ===== QUALITY009: Naming Conventions Config Tests =====
+
+    #[tokio::test]
+    async fn test_check_naming_conventions_config_missing() {
+        let temp_dir = TempDir::new().unwrap();
+        let root = temp_dir.path();
+
+        let scanner = Scanner::new(root.to_path_buf());
+        let findings = check_naming_conventions_config(&scanner).await.unwrap();
+
+        assert!(!findings.is_empty());
+        assert!(findings.iter().any(|f| f.rule_id == "QUALITY009"));
+    }
+
+    #[tokio::test]
+    async fn test_check_naming_conventions_config_with_eslint() {
+        let temp_dir = TempDir::new().unwrap();
+        let root = temp_dir.path();
+        fs::write(
+            root.join(".eslintrc.json"),
+            r#"{"rules": {"@typescript-eslint/naming-convention": "error"}}"#,
+        )
+        .unwrap();
+
+        let scanner = Scanner::new(root.to_path_buf());
+        let findings = check_naming_conventions_config(&scanner).await.unwrap();
+
+        assert!(findings.iter().all(|f| f.rule_id != "QUALITY009"));
+    }
+
+    #[tokio::test]
+    async fn test_check_naming_conventions_config_with_pylint() {
+        let temp_dir = TempDir::new().unwrap();
+        let root = temp_dir.path();
+        fs::write(
+            root.join(".pylintrc"),
+            "[BASIC]\nvariable-naming-style=snake_case",
+        )
+        .unwrap();
+
+        let scanner = Scanner::new(root.to_path_buf());
+        let findings = check_naming_conventions_config(&scanner).await.unwrap();
+
+        assert!(findings.iter().all(|f| f.rule_id != "QUALITY009"));
+    }
+
+    #[tokio::test]
+    async fn test_check_naming_conventions_config_with_editorconfig() {
+        let temp_dir = TempDir::new().unwrap();
+        let root = temp_dir.path();
+        fs::write(
+            root.join(".editorconfig"),
+            "root = true\n[*.cs]\ndotnet_naming_rule.example = true",
+        )
+        .unwrap();
+
+        let scanner = Scanner::new(root.to_path_buf());
+        let findings = check_naming_conventions_config(&scanner).await.unwrap();
+
+        assert!(findings.iter().all(|f| f.rule_id != "QUALITY009"));
     }
 }

--- a/src/rules/categories/workflows.rs
+++ b/src/rules/categories/workflows.rs
@@ -4,6 +4,12 @@
 //! - Hardcoded secrets in workflow files
 //! - Explicit permissions configuration
 //! - Pinned action versions for security
+//! - Job timeout configuration
+//! - Concurrency controls
+//! - Reusable workflow suggestions
+//! - Artifact retention configuration
+//! - pull_request_target security
+//! - Linter integration in CI
 
 use crate::error::RepoLensError;
 use regex::Regex;
@@ -12,6 +18,7 @@ use crate::config::Config;
 use crate::rules::engine::RuleCategory;
 use crate::rules::results::{Finding, Severity};
 use crate::scanner::Scanner;
+use crate::utils::language_detection::{detect_languages, Language};
 
 /// Rules for checking GitHub Actions workflows
 pub struct WorkflowsRules;
@@ -54,6 +61,36 @@ impl RuleCategory for WorkflowsRules {
         // Check pinned actions
         if config.is_rule_enabled("workflows/pinned-actions") {
             findings.extend(check_pinned_actions(scanner, config).await?);
+        }
+
+        // Check workflow timeout
+        if config.is_rule_enabled("workflows/timeout") {
+            findings.extend(check_workflow_timeout(scanner).await?);
+        }
+
+        // Check workflow concurrency
+        if config.is_rule_enabled("workflows/concurrency") {
+            findings.extend(check_workflow_concurrency(scanner).await?);
+        }
+
+        // Check reusable workflows
+        if config.is_rule_enabled("workflows/reusable-workflows") {
+            findings.extend(check_reusable_workflows(scanner).await?);
+        }
+
+        // Check artifacts retention
+        if config.is_rule_enabled("workflows/artifacts-retention") {
+            findings.extend(check_artifacts_retention(scanner).await?);
+        }
+
+        // Check pull_request_target security
+        if config.is_rule_enabled("workflows/pull-request-target") {
+            findings.extend(check_pull_request_target(scanner).await?);
+        }
+
+        // Check linters in CI
+        if config.is_rule_enabled("workflows/linters-in-ci") {
+            findings.extend(check_linters_in_ci(scanner).await?);
         }
 
         Ok(findings)
@@ -235,6 +272,388 @@ async fn check_pinned_actions(
                         );
                     }
                 }
+            }
+        }
+    }
+
+    Ok(findings)
+}
+
+/// Check for job timeout configuration in workflow files
+///
+/// Jobs without `timeout-minutes` can run indefinitely, wasting resources.
+///
+/// # Arguments
+///
+/// * `scanner` - The scanner to access repository files
+///
+/// # Returns
+///
+/// A vector of findings for jobs missing timeout configuration
+async fn check_workflow_timeout(scanner: &Scanner) -> Result<Vec<Finding>, RepoLensError> {
+    let mut findings = Vec::new();
+
+    for file in scanner.files_in_directory(".github/workflows") {
+        if !file.path.ends_with(".yml") && !file.path.ends_with(".yaml") {
+            continue;
+        }
+
+        if let Ok(content) = scanner.read_file(&file.path) {
+            let mut in_jobs = false;
+            let mut current_job: Option<String> = None;
+            let mut job_has_timeout = false;
+
+            for line in content.lines() {
+                let trimmed = line.trim();
+
+                // Detect the jobs: section
+                if line == "jobs:" || line.starts_with("jobs:") {
+                    in_jobs = true;
+                    continue;
+                }
+
+                if !in_jobs {
+                    continue;
+                }
+
+                // A top-level key under jobs (indented by exactly 2 spaces, no more)
+                if line.starts_with("  ") && !line.starts_with("    ") && trimmed.ends_with(':') {
+                    // Save previous job findings
+                    if let Some(ref job_name) = current_job {
+                        if !job_has_timeout {
+                            findings.push(
+                                Finding::new(
+                                    "WF004",
+                                    "workflows",
+                                    Severity::Warning,
+                                    format!(
+                                        "Job '{}' missing timeout-minutes",
+                                        job_name
+                                    ),
+                                )
+                                .with_location(&file.path)
+                                .with_description(
+                                    "Jobs without timeout-minutes can run indefinitely, consuming resources and potentially incurring costs.",
+                                )
+                                .with_remediation(
+                                    "Add 'timeout-minutes:' to each job to limit maximum execution time.",
+                                ),
+                            );
+                        }
+                    }
+                    current_job = Some(trimmed.trim_end_matches(':').to_string());
+                    job_has_timeout = false;
+                    continue;
+                }
+
+                if current_job.is_some() && trimmed.starts_with("timeout-minutes:") {
+                    job_has_timeout = true;
+                }
+
+                // If we encounter a top-level key (no indentation), we're out of jobs
+                if !line.starts_with(' ') && !trimmed.is_empty() && trimmed.ends_with(':') {
+                    in_jobs = false;
+                }
+            }
+
+            // Check the last job
+            if let Some(ref job_name) = current_job {
+                if !job_has_timeout {
+                    findings.push(
+                        Finding::new(
+                            "WF004",
+                            "workflows",
+                            Severity::Warning,
+                            format!("Job '{}' missing timeout-minutes", job_name),
+                        )
+                        .with_location(&file.path)
+                        .with_description(
+                            "Jobs without timeout-minutes can run indefinitely, consuming resources and potentially incurring costs.",
+                        )
+                        .with_remediation(
+                            "Add 'timeout-minutes:' to each job to limit maximum execution time.",
+                        ),
+                    );
+                }
+            }
+        }
+    }
+
+    Ok(findings)
+}
+
+/// Check for concurrency configuration in workflow files
+///
+/// Concurrency controls prevent duplicate workflow runs and save resources.
+///
+/// # Arguments
+///
+/// * `scanner` - The scanner to access repository files
+///
+/// # Returns
+///
+/// A vector of findings for missing concurrency configuration
+async fn check_workflow_concurrency(scanner: &Scanner) -> Result<Vec<Finding>, RepoLensError> {
+    let mut findings = Vec::new();
+
+    let workflow_files: Vec<_> = scanner
+        .files_in_directory(".github/workflows")
+        .into_iter()
+        .filter(|f| f.path.ends_with(".yml") || f.path.ends_with(".yaml"))
+        .collect();
+
+    let any_has_concurrency = workflow_files.iter().any(|file| {
+        scanner
+            .read_file(&file.path)
+            .map(|content| content.contains("concurrency:"))
+            .unwrap_or(false)
+    });
+
+    if !any_has_concurrency && !workflow_files.is_empty() {
+        findings.push(
+            Finding::new(
+                "WF005",
+                "workflows",
+                Severity::Info,
+                "No workflow uses concurrency controls",
+            )
+            .with_description(
+                "Concurrency controls can prevent duplicate workflow runs and save CI resources.",
+            )
+            .with_remediation(
+                "Add a 'concurrency:' block to workflows to cancel redundant runs on the same branch.",
+            ),
+        );
+    }
+
+    Ok(findings)
+}
+
+/// Check if reusable workflows should be used
+///
+/// When there are 3 or more workflow files, suggests using reusable workflows
+/// to reduce duplication.
+///
+/// # Arguments
+///
+/// * `scanner` - The scanner to access repository files
+///
+/// # Returns
+///
+/// A vector of findings for reusable workflow suggestions
+async fn check_reusable_workflows(scanner: &Scanner) -> Result<Vec<Finding>, RepoLensError> {
+    let mut findings = Vec::new();
+
+    let workflow_files: Vec<_> = scanner
+        .files_in_directory(".github/workflows")
+        .into_iter()
+        .filter(|f| f.path.ends_with(".yml") || f.path.ends_with(".yaml"))
+        .collect();
+
+    if workflow_files.len() >= 3 {
+        let has_workflow_call = workflow_files.iter().any(|file| {
+            scanner
+                .read_file(&file.path)
+                .map(|content| content.contains("workflow_call"))
+                .unwrap_or(false)
+        });
+
+        if !has_workflow_call {
+            findings.push(
+                Finding::new(
+                    "WF006",
+                    "workflows",
+                    Severity::Info,
+                    "Consider using reusable workflows",
+                )
+                .with_description(
+                    "With multiple workflow files, reusable workflows can reduce duplication and improve maintainability.",
+                )
+                .with_remediation(
+                    "Create reusable workflows with 'workflow_call' trigger to share common steps across workflows.",
+                ),
+            );
+        }
+    }
+
+    Ok(findings)
+}
+
+/// Check for artifact retention configuration
+///
+/// upload-artifact actions without retention-days may keep artifacts
+/// longer than necessary, increasing storage costs.
+///
+/// # Arguments
+///
+/// * `scanner` - The scanner to access repository files
+///
+/// # Returns
+///
+/// A vector of findings for missing retention configuration
+async fn check_artifacts_retention(scanner: &Scanner) -> Result<Vec<Finding>, RepoLensError> {
+    let mut findings = Vec::new();
+
+    for file in scanner.files_in_directory(".github/workflows") {
+        if !file.path.ends_with(".yml") && !file.path.ends_with(".yaml") {
+            continue;
+        }
+
+        if let Ok(content) = scanner.read_file(&file.path) {
+            if content.contains("upload-artifact") && !content.contains("retention-days") {
+                findings.push(
+                    Finding::new(
+                        "WF007",
+                        "workflows",
+                        Severity::Warning,
+                        "upload-artifact used without retention-days",
+                    )
+                    .with_location(&file.path)
+                    .with_description(
+                        "Artifacts without explicit retention-days use the repository default (90 days), which may increase storage costs.",
+                    )
+                    .with_remediation(
+                        "Add 'retention-days' parameter to upload-artifact steps to control artifact storage duration.",
+                    ),
+                );
+            }
+        }
+    }
+
+    Ok(findings)
+}
+
+/// Check for pull_request_target with checkout security risk
+///
+/// Using `pull_request_target` with `actions/checkout` of the PR head
+/// can expose repository secrets to untrusted code.
+///
+/// # Arguments
+///
+/// * `scanner` - The scanner to access repository files
+///
+/// # Returns
+///
+/// A vector of findings for pull_request_target security risks
+async fn check_pull_request_target(scanner: &Scanner) -> Result<Vec<Finding>, RepoLensError> {
+    let mut findings = Vec::new();
+
+    for file in scanner.files_in_directory(".github/workflows") {
+        if !file.path.ends_with(".yml") && !file.path.ends_with(".yaml") {
+            continue;
+        }
+
+        if let Ok(content) = scanner.read_file(&file.path) {
+            if content.contains("pull_request_target") && content.contains("actions/checkout") {
+                findings.push(
+                    Finding::new(
+                        "WF008",
+                        "workflows",
+                        Severity::Warning,
+                        "pull_request_target with checkout detected",
+                    )
+                    .with_location(&file.path)
+                    .with_description(
+                        "Using pull_request_target with actions/checkout can expose repository secrets to untrusted PR code. This is a known security risk.",
+                    )
+                    .with_remediation(
+                        "Avoid checking out PR head ref in pull_request_target workflows. If needed, use a separate workflow with limited permissions.",
+                    ),
+                );
+            }
+        }
+    }
+
+    Ok(findings)
+}
+
+/// Check for linter integration in CI workflows
+///
+/// Detects project languages and checks if appropriate linters are
+/// configured in CI workflows.
+///
+/// # Arguments
+///
+/// * `scanner` - The scanner to access repository files
+///
+/// # Returns
+///
+/// A vector of findings for missing linter integration
+async fn check_linters_in_ci(scanner: &Scanner) -> Result<Vec<Finding>, RepoLensError> {
+    let mut findings = Vec::new();
+
+    let languages = detect_languages(scanner);
+    if languages.is_empty() {
+        return Ok(findings);
+    }
+
+    // Collect all workflow content
+    let mut all_workflow_content = String::new();
+    for file in scanner.files_in_directory(".github/workflows") {
+        if !file.path.ends_with(".yml") && !file.path.ends_with(".yaml") {
+            continue;
+        }
+        if let Ok(content) = scanner.read_file(&file.path) {
+            all_workflow_content.push_str(&content);
+            all_workflow_content.push('\n');
+        }
+    }
+
+    let content_lower = all_workflow_content.to_lowercase();
+
+    // Known linter commands/actions by language
+    let linter_keywords: Vec<(Language, &[&str], &str)> = vec![
+        (
+            Language::Rust,
+            &["clippy", "cargo fmt", "cargo-fmt", "rustfmt"],
+            "clippy and rustfmt (e.g., 'cargo clippy' and 'cargo fmt --check')",
+        ),
+        (
+            Language::JavaScript,
+            &["eslint", "prettier", "biome", "oxlint"],
+            "ESLint and Prettier (e.g., 'npx eslint .' and 'npx prettier --check .')",
+        ),
+        (
+            Language::Python,
+            &["pylint", "flake8", "black", "ruff", "mypy", "pyright"],
+            "Ruff, Flake8, or Pylint (e.g., 'ruff check .' or 'flake8')",
+        ),
+        (
+            Language::Go,
+            &["golangci-lint", "golangci", "go vet", "staticcheck"],
+            "golangci-lint (e.g., 'golangci-lint run')",
+        ),
+        (
+            Language::Ruby,
+            &["rubocop", "standardrb"],
+            "RuboCop (e.g., 'bundle exec rubocop')",
+        ),
+        (
+            Language::Php,
+            &["phpstan", "psalm", "phpcs", "php-cs-fixer"],
+            "PHPStan or PHP_CodeSniffer (e.g., 'phpstan analyse')",
+        ),
+    ];
+
+    for (language, keywords, suggestion) in &linter_keywords {
+        if languages.contains(language) {
+            let has_linter = keywords.iter().any(|kw| content_lower.contains(kw));
+            if !has_linter {
+                findings.push(
+                    Finding::new(
+                        "WF009",
+                        "workflows",
+                        Severity::Warning,
+                        format!("No linter step found in CI for {:?}", language),
+                    )
+                    .with_description(
+                        "Running linters in CI ensures code quality standards are enforced automatically.",
+                    )
+                    .with_remediation(format!(
+                        "Add a linting step to your CI workflow using {}.",
+                        suggestion
+                    )),
+                );
             }
         }
     }
@@ -573,5 +992,347 @@ mod tests {
         assert!(findings.iter().all(|f| f.rule_id != "WF001"));
         // WF002 should still be found
         assert!(findings.iter().any(|f| f.rule_id == "WF002"));
+    }
+
+    // ===== WF004: Workflow Timeout Tests =====
+
+    #[tokio::test]
+    async fn test_check_workflow_timeout_missing() {
+        let temp_dir = TempDir::new().unwrap();
+        let root = temp_dir.path();
+        let workflows_dir = root.join(".github").join("workflows");
+        fs::create_dir_all(&workflows_dir).unwrap();
+
+        fs::write(
+            workflows_dir.join("ci.yml"),
+            "name: CI\non: push\njobs:\n  test:\n    runs-on: ubuntu-latest\n    steps:\n      - uses: actions/checkout@v4",
+        )
+        .unwrap();
+
+        let scanner = Scanner::new(root.to_path_buf());
+        let findings = check_workflow_timeout(&scanner).await.unwrap();
+
+        assert!(!findings.is_empty());
+        assert!(findings.iter().any(|f| f.rule_id == "WF004"));
+    }
+
+    #[tokio::test]
+    async fn test_check_workflow_timeout_present() {
+        let temp_dir = TempDir::new().unwrap();
+        let root = temp_dir.path();
+        let workflows_dir = root.join(".github").join("workflows");
+        fs::create_dir_all(&workflows_dir).unwrap();
+
+        fs::write(
+            workflows_dir.join("ci.yml"),
+            "name: CI\non: push\njobs:\n  test:\n    runs-on: ubuntu-latest\n    timeout-minutes: 30\n    steps:\n      - uses: actions/checkout@v4",
+        )
+        .unwrap();
+
+        let scanner = Scanner::new(root.to_path_buf());
+        let findings = check_workflow_timeout(&scanner).await.unwrap();
+
+        assert!(findings.iter().all(|f| f.rule_id != "WF004"));
+    }
+
+    // ===== WF005: Workflow Concurrency Tests =====
+
+    #[tokio::test]
+    async fn test_check_workflow_concurrency_missing() {
+        let temp_dir = TempDir::new().unwrap();
+        let root = temp_dir.path();
+        let workflows_dir = root.join(".github").join("workflows");
+        fs::create_dir_all(&workflows_dir).unwrap();
+
+        fs::write(
+            workflows_dir.join("ci.yml"),
+            "name: CI\non: push\njobs:\n  test:\n    runs-on: ubuntu-latest",
+        )
+        .unwrap();
+
+        let scanner = Scanner::new(root.to_path_buf());
+        let findings = check_workflow_concurrency(&scanner).await.unwrap();
+
+        assert!(!findings.is_empty());
+        assert!(findings.iter().any(|f| f.rule_id == "WF005"));
+    }
+
+    #[tokio::test]
+    async fn test_check_workflow_concurrency_present() {
+        let temp_dir = TempDir::new().unwrap();
+        let root = temp_dir.path();
+        let workflows_dir = root.join(".github").join("workflows");
+        fs::create_dir_all(&workflows_dir).unwrap();
+
+        fs::write(
+            workflows_dir.join("ci.yml"),
+            "name: CI\non: push\nconcurrency:\n  group: ci-${{ github.ref }}\njobs:\n  test:\n    runs-on: ubuntu-latest",
+        )
+        .unwrap();
+
+        let scanner = Scanner::new(root.to_path_buf());
+        let findings = check_workflow_concurrency(&scanner).await.unwrap();
+
+        assert!(findings.iter().all(|f| f.rule_id != "WF005"));
+    }
+
+    // ===== WF006: Reusable Workflows Tests =====
+
+    #[tokio::test]
+    async fn test_check_reusable_workflows_no_suggestion_few_files() {
+        let temp_dir = TempDir::new().unwrap();
+        let root = temp_dir.path();
+        let workflows_dir = root.join(".github").join("workflows");
+        fs::create_dir_all(&workflows_dir).unwrap();
+
+        fs::write(workflows_dir.join("ci.yml"), "name: CI\non: push").unwrap();
+        fs::write(workflows_dir.join("deploy.yml"), "name: Deploy\non: push").unwrap();
+
+        let scanner = Scanner::new(root.to_path_buf());
+        let findings = check_reusable_workflows(&scanner).await.unwrap();
+
+        // Only 2 workflow files, no suggestion
+        assert!(findings.iter().all(|f| f.rule_id != "WF006"));
+    }
+
+    #[tokio::test]
+    async fn test_check_reusable_workflows_suggests_when_many_files() {
+        let temp_dir = TempDir::new().unwrap();
+        let root = temp_dir.path();
+        let workflows_dir = root.join(".github").join("workflows");
+        fs::create_dir_all(&workflows_dir).unwrap();
+
+        fs::write(workflows_dir.join("ci.yml"), "name: CI\non: push").unwrap();
+        fs::write(workflows_dir.join("deploy.yml"), "name: Deploy\non: push").unwrap();
+        fs::write(workflows_dir.join("lint.yml"), "name: Lint\non: push").unwrap();
+
+        let scanner = Scanner::new(root.to_path_buf());
+        let findings = check_reusable_workflows(&scanner).await.unwrap();
+
+        assert!(findings.iter().any(|f| f.rule_id == "WF006"));
+    }
+
+    #[tokio::test]
+    async fn test_check_reusable_workflows_no_suggestion_when_workflow_call_exists() {
+        let temp_dir = TempDir::new().unwrap();
+        let root = temp_dir.path();
+        let workflows_dir = root.join(".github").join("workflows");
+        fs::create_dir_all(&workflows_dir).unwrap();
+
+        fs::write(workflows_dir.join("ci.yml"), "name: CI\non: push").unwrap();
+        fs::write(workflows_dir.join("deploy.yml"), "name: Deploy\non: push").unwrap();
+        fs::write(
+            workflows_dir.join("shared.yml"),
+            "name: Shared\non:\n  workflow_call:\njobs:\n  build:\n    runs-on: ubuntu-latest",
+        )
+        .unwrap();
+
+        let scanner = Scanner::new(root.to_path_buf());
+        let findings = check_reusable_workflows(&scanner).await.unwrap();
+
+        assert!(findings.iter().all(|f| f.rule_id != "WF006"));
+    }
+
+    // ===== WF007: Artifacts Retention Tests =====
+
+    #[tokio::test]
+    async fn test_check_artifacts_retention_missing() {
+        let temp_dir = TempDir::new().unwrap();
+        let root = temp_dir.path();
+        let workflows_dir = root.join(".github").join("workflows");
+        fs::create_dir_all(&workflows_dir).unwrap();
+
+        fs::write(
+            workflows_dir.join("ci.yml"),
+            "name: CI\non: push\njobs:\n  test:\n    steps:\n      - uses: actions/upload-artifact@v4\n        with:\n          name: build\n          path: dist/",
+        )
+        .unwrap();
+
+        let scanner = Scanner::new(root.to_path_buf());
+        let findings = check_artifacts_retention(&scanner).await.unwrap();
+
+        assert!(!findings.is_empty());
+        assert!(findings.iter().any(|f| f.rule_id == "WF007"));
+    }
+
+    #[tokio::test]
+    async fn test_check_artifacts_retention_present() {
+        let temp_dir = TempDir::new().unwrap();
+        let root = temp_dir.path();
+        let workflows_dir = root.join(".github").join("workflows");
+        fs::create_dir_all(&workflows_dir).unwrap();
+
+        fs::write(
+            workflows_dir.join("ci.yml"),
+            "name: CI\non: push\njobs:\n  test:\n    steps:\n      - uses: actions/upload-artifact@v4\n        with:\n          name: build\n          path: dist/\n          retention-days: 5",
+        )
+        .unwrap();
+
+        let scanner = Scanner::new(root.to_path_buf());
+        let findings = check_artifacts_retention(&scanner).await.unwrap();
+
+        assert!(findings.iter().all(|f| f.rule_id != "WF007"));
+    }
+
+    // ===== WF008: pull_request_target Tests =====
+
+    #[tokio::test]
+    async fn test_check_pull_request_target_with_checkout() {
+        let temp_dir = TempDir::new().unwrap();
+        let root = temp_dir.path();
+        let workflows_dir = root.join(".github").join("workflows");
+        fs::create_dir_all(&workflows_dir).unwrap();
+
+        fs::write(
+            workflows_dir.join("pr.yml"),
+            "name: PR\non: pull_request_target\njobs:\n  test:\n    steps:\n      - uses: actions/checkout@v4\n        with:\n          ref: ${{ github.event.pull_request.head.sha }}",
+        )
+        .unwrap();
+
+        let scanner = Scanner::new(root.to_path_buf());
+        let findings = check_pull_request_target(&scanner).await.unwrap();
+
+        assert!(!findings.is_empty());
+        assert!(findings.iter().any(|f| f.rule_id == "WF008"));
+    }
+
+    #[tokio::test]
+    async fn test_check_pull_request_target_without_checkout() {
+        let temp_dir = TempDir::new().unwrap();
+        let root = temp_dir.path();
+        let workflows_dir = root.join(".github").join("workflows");
+        fs::create_dir_all(&workflows_dir).unwrap();
+
+        fs::write(
+            workflows_dir.join("pr.yml"),
+            "name: PR\non: pull_request_target\njobs:\n  label:\n    steps:\n      - uses: actions/labeler@v4",
+        )
+        .unwrap();
+
+        let scanner = Scanner::new(root.to_path_buf());
+        let findings = check_pull_request_target(&scanner).await.unwrap();
+
+        assert!(findings.iter().all(|f| f.rule_id != "WF008"));
+    }
+
+    #[tokio::test]
+    async fn test_check_pull_request_target_no_trigger() {
+        let temp_dir = TempDir::new().unwrap();
+        let root = temp_dir.path();
+        let workflows_dir = root.join(".github").join("workflows");
+        fs::create_dir_all(&workflows_dir).unwrap();
+
+        fs::write(
+            workflows_dir.join("ci.yml"),
+            "name: CI\non: push\njobs:\n  test:\n    steps:\n      - uses: actions/checkout@v4",
+        )
+        .unwrap();
+
+        let scanner = Scanner::new(root.to_path_buf());
+        let findings = check_pull_request_target(&scanner).await.unwrap();
+
+        assert!(findings.is_empty());
+    }
+
+    // ===== WF009: Linters in CI Tests =====
+
+    #[tokio::test]
+    async fn test_check_linters_in_ci_missing_for_rust() {
+        let temp_dir = TempDir::new().unwrap();
+        let root = temp_dir.path();
+        let workflows_dir = root.join(".github").join("workflows");
+        fs::create_dir_all(&workflows_dir).unwrap();
+
+        fs::write(root.join("Cargo.toml"), "[package]\nname = \"test\"").unwrap();
+        fs::write(
+            workflows_dir.join("ci.yml"),
+            "name: CI\non: push\njobs:\n  test:\n    steps:\n      - run: cargo test",
+        )
+        .unwrap();
+
+        let scanner = Scanner::new(root.to_path_buf());
+        let findings = check_linters_in_ci(&scanner).await.unwrap();
+
+        assert!(findings.iter().any(|f| f.rule_id == "WF009"));
+    }
+
+    #[tokio::test]
+    async fn test_check_linters_in_ci_present_for_rust() {
+        let temp_dir = TempDir::new().unwrap();
+        let root = temp_dir.path();
+        let workflows_dir = root.join(".github").join("workflows");
+        fs::create_dir_all(&workflows_dir).unwrap();
+
+        fs::write(root.join("Cargo.toml"), "[package]\nname = \"test\"").unwrap();
+        fs::write(
+            workflows_dir.join("ci.yml"),
+            "name: CI\non: push\njobs:\n  test:\n    steps:\n      - run: cargo clippy\n      - run: cargo test",
+        )
+        .unwrap();
+
+        let scanner = Scanner::new(root.to_path_buf());
+        let findings = check_linters_in_ci(&scanner).await.unwrap();
+
+        assert!(findings.iter().all(|f| f.rule_id != "WF009"));
+    }
+
+    #[tokio::test]
+    async fn test_check_linters_in_ci_no_languages() {
+        let temp_dir = TempDir::new().unwrap();
+        let root = temp_dir.path();
+        let workflows_dir = root.join(".github").join("workflows");
+        fs::create_dir_all(&workflows_dir).unwrap();
+
+        fs::write(
+            workflows_dir.join("ci.yml"),
+            "name: CI\non: push\njobs:\n  test:\n    runs-on: ubuntu-latest",
+        )
+        .unwrap();
+
+        let scanner = Scanner::new(root.to_path_buf());
+        let findings = check_linters_in_ci(&scanner).await.unwrap();
+
+        // No detectable languages, no WF009 findings
+        assert!(findings.iter().all(|f| f.rule_id != "WF009"));
+    }
+
+    #[tokio::test]
+    async fn test_check_linters_in_ci_missing_for_javascript() {
+        let temp_dir = TempDir::new().unwrap();
+        let root = temp_dir.path();
+        let workflows_dir = root.join(".github").join("workflows");
+        fs::create_dir_all(&workflows_dir).unwrap();
+
+        fs::write(root.join("package.json"), r#"{"name": "test"}"#).unwrap();
+        fs::write(
+            workflows_dir.join("ci.yml"),
+            "name: CI\non: push\njobs:\n  test:\n    steps:\n      - run: npm test",
+        )
+        .unwrap();
+
+        let scanner = Scanner::new(root.to_path_buf());
+        let findings = check_linters_in_ci(&scanner).await.unwrap();
+
+        assert!(findings.iter().any(|f| f.rule_id == "WF009"));
+    }
+
+    #[tokio::test]
+    async fn test_check_linters_in_ci_present_for_javascript() {
+        let temp_dir = TempDir::new().unwrap();
+        let root = temp_dir.path();
+        let workflows_dir = root.join(".github").join("workflows");
+        fs::create_dir_all(&workflows_dir).unwrap();
+
+        fs::write(root.join("package.json"), r#"{"name": "test"}"#).unwrap();
+        fs::write(
+            workflows_dir.join("ci.yml"),
+            "name: CI\non: push\njobs:\n  lint:\n    steps:\n      - run: npx eslint .\n  test:\n    steps:\n      - run: npm test",
+        )
+        .unwrap();
+
+        let scanner = Scanner::new(root.to_path_buf());
+        let findings = check_linters_in_ci(&scanner).await.unwrap();
+
+        assert!(findings.iter().all(|f| f.rule_id != "WF009"));
     }
 }

--- a/src/rules/engine.rs
+++ b/src/rules/engine.rs
@@ -5,9 +5,9 @@ use crate::error::RepoLensError;
 use tracing::{debug, info, span, Level};
 
 use super::categories::{
-    custom::CustomRules, dependencies::DependencyRules, docs::DocsRules, files::FilesRules,
-    licenses::LicenseRules, quality::QualityRules, secrets::SecretsRules, security::SecurityRules,
-    workflows::WorkflowsRules,
+    custom::CustomRules, dependencies::DependencyRules, docker::DockerRules, docs::DocsRules,
+    files::FilesRules, licenses::LicenseRules, quality::QualityRules, secrets::SecretsRules,
+    security::SecurityRules, workflows::WorkflowsRules,
 };
 use super::results::AuditResults;
 use crate::config::Config;
@@ -122,6 +122,7 @@ impl RulesEngine {
             Box::new(QualityRules),
             Box::new(DependencyRules),
             Box::new(LicenseRules),
+            Box::new(DockerRules),
             Box::new(CustomRules),
         ];
 


### PR DESCRIPTION
## Summary

- **Docker rules** (DOCKER001-008): Dockerfile presence, .dockerignore, FROM pinning, USER instruction, HEALTHCHECK, multi-stage builds, secrets in ENV, COPY without .dockerignore — Closes #149
- **CI/CD advanced rules** (WF004-009): workflow timeout, concurrency, reusable workflows, artifacts retention, pull_request_target safety, linters in CI — Closes #151, Closes #8
- **Quality rules** (QUALITY005-009): test coverage config, API docs, complexity tools, dead code detection, naming conventions — Closes #12, Closes #11, Closes #45
- **CHANGELOG rules** (DOC008-010): CHANGELOG.md presence, Keep a Changelog format, empty Unreleased section — Closes #150
- **Java ecosystem** (Maven/Gradle): dependency parsing from pom.xml and build.gradle, license extraction from pom.xml — Closes #153
- **PHP ecosystem** (Composer): dependency parsing from composer.lock/composer.json, license extraction — Closes #154
- All 3 presets (opensource, enterprise, strict) updated with new rules
- **+3600 lines**, 9 files modified, 1 new file, **722 tests passing**

## Test plan

- [x] `cargo check` — compiles without errors
- [x] `cargo clippy` — no warnings
- [x] `cargo fmt` — properly formatted
- [x] `cargo test` — 722 tests, 0 failures
- [ ] Manual testing with a real repository

🤖 Generated with [Claude Code](https://claude.com/claude-code)