### PR TITLE
fix(cli): drop needless borrow for dialoguer 0.12 clippy lint

### DIFF
--- a/crates/repolens/src/cli/commands/init.rs
+++ b/crates/repolens/src/cli/commands/init.rs
@@ -154,7 +154,7 @@ fn select_preset() -> Result<Preset, RepoLensError> {
 
     let selection = Select::new()
         .with_prompt("Select a preset")
-        .items(&presets.iter().map(|(_, desc)| *desc).collect::<Vec<_>>())
+        .items(presets.iter().map(|(_, desc)| *desc).collect::<Vec<_>>())
         .default(0)
         .interact()
         .map_err(|e| {


### PR DESCRIPTION
Restores main CI green after the dialoguer 0.11→0.12 bump (#246). dialoguer 0.12's `Select::items` takes an `IntoIterator` generic, so the `&Vec` borrow trips `clippy::needless_borrows_for_generic_args`, which CI runs as `-D warnings`. One-line fix: pass the Vec by value. Verified: clippy -D warnings clean, fmt clean, 916 tests pass.